### PR TITLE
cli/validate: log failed HARD_CHECK_KEYS for hard verification

### DIFF
--- a/grail/cli/validate.py
+++ b/grail/cli/validate.py
@@ -1248,9 +1248,11 @@ async def _process_wallet_window(
                 if not hard_valid:
                     pr_invalid_proof += 1
                     hard_failure = True
+                    failed_keys = [k for k in HARD_CHECK_KEYS if not checks.get(k, False)]
                     logger.warning(
                         f"Hard verification failed for uid {uid_str}; "
-                        f"invalidating uid for window {target_window}"
+                        f"invalidating uid for window {target_window}; "
+                        f"failed checks = {failed_keys}"
                     )
                     break
                 if not soft_valid:


### PR DESCRIPTION
Log which HARD_CHECK_KEYS failed in grail/cli/validate.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI validator now includes clearer error output on hard verification failures. It lists the specific checks that failed, helping users quickly identify the root cause when validation does not pass. No changes to the execution flow or error handling—only improved visibility into failure details to aid troubleshooting without altering existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->