### PR TITLE
feat(miner): vLLM backend for GRPO (EOS termination, logprobs fallback); + benchmark

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,17 @@ BT_WALLET_COLD=
 # This key is safe to use online and used for mining, validation, or inference.
 BT_WALLET_HOT=default
 
+
+# choose backend
+# vllm or hf
+INFERENCE_BACKEND=vllm
+
+# extra vllm settings
+VLLM_BASE_URL=http://127.0.0.1:8000
+VLLM_MODEL=Qwen/Qwen3-4B-Instruct-2507
+VLLM_TIMEOUT_S=30
+VLLM_MAX_RETRIES=2
+
 # ============================================================================
 # OPTIONAL: STORAGE (Cloudflare R2) - DUAL CREDENTIAL SYSTEM
 # ============================================================================

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -52,16 +52,25 @@ Hardware requirements:
 # Clone and enter
 git clone https://github.com/one-covenant/grail
 cd grail
-
-# Create venv and install
-uv venv && source .venv/bin/activate
-
 # Recommended (reproducible, uses lockfile and installs extras)
 uv sync
 
+source .venv/bin/activate
+
+# Optional install vllm and use as backend
+
+uv pip install vllm 
+
+vllm serve Qwen/Qwen3-4B-Instruct-2507 \
+  --port 8000 --tensor-parallel-size 1 \
+  --dtype bfloat16 --max-model-len 8192 \
+  --gpu-memory-utilization 0.65 --enforce-eager \
+  --generation-config vllm \
+  --trust-remote-code
+
 # Configure environment
 cp .env.example .env
-# Edit .env with your wallet names, network, and R2 credentials
+# Edit .env with your wallet names, network, R2 credentials and vllm/hf backend selection
 
 # Run miner
 grail mine 

--- a/grail/inference/__init__.py
+++ b/grail/inference/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# Namespace for inference backends (vLLM, etc.)
+
+

--- a/grail/inference/vllm_client.py
+++ b/grail/inference/vllm_client.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""vLLM HTTP client for high-throughput generation.
+
+Supports OpenAI-compatible /v1/completions endpoint exposed by vllm serve.
+We send a rendered prompt (already chat-templated) and request n completions
+with token-level logprobs when available.
+
+This client is intentionally lightweight and does not depend on the vllm
+python package, only on 'requests'.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VLLMCompletion:
+    text: str
+    token_logprobs: Optional[List[float]]
+
+
+class VLLMClient:
+    def __init__(
+        self,
+        base_url: str,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: float = 30.0,
+        max_retries: int = 2,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key or os.getenv("VLLM_API_KEY") or ""
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+        # Prefer OpenAI-compatible /v1/completions for simple prompt-based gen
+        self.completions_url = f"{self.base_url}/v1/completions"
+
+        self._session = requests.Session()
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        n: int,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        top_k: int,
+        repetition_penalty: Optional[float] = None,
+        stop: Optional[List[str]] = None,
+        ignore_eos: bool = True,
+    ) -> List[VLLMCompletion]:
+        """Generate n completions for a single prompt.
+
+        Args:
+            prompt: Fully rendered prompt string (after chat templating)
+            n: Number of completions to return (GRPO group size)
+            max_tokens: Maximum new tokens to sample
+            temperature: Sampling temperature
+            top_p: nucleus sampling
+            repetition_penalty: Not universally supported in OpenAI schema; ignored if None
+            stop: Optional stop strings
+
+        Returns:
+            List of VLLMCompletion with text and optional token-level logprobs
+        """
+        payload: Dict[str, Any] = {
+            "prompt": prompt,
+            "max_tokens": int(max_tokens),
+            "temperature": float(temperature),
+            "top_p": float(top_p),
+            "top_k": int(top_k),
+            "n": int(n),
+            "logprobs": 1,  # request per-token logprobs when supported
+            "echo": False,
+        }
+        # Encourage length-based termination to match miner's MAX_NEW_TOKENS path
+        # when OpenAI-compatible wrapper supports it.
+        payload["ignore_eos"] = bool(ignore_eos)
+        if self.model:
+            payload["model"] = self.model
+        if stop:
+            payload["stop"] = stop
+        # repetition_penalty is not part of OpenAI schema; some vLLM deployments
+        # accept it as an extension. Include when provided.
+        if repetition_penalty is not None:
+            payload["repetition_penalty"] = float(repetition_penalty)
+
+        last_error: Optional[Exception] = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                resp = self._session.post(
+                    self.completions_url,
+                    data=json.dumps(payload),
+                    headers=self._headers(),
+                    timeout=self.timeout,
+                )
+                if resp.status_code != 200:
+                    raise RuntimeError(
+                        f"vLLM server HTTP {resp.status_code}: {resp.text[:200]}"
+                    )
+                data = resp.json()
+                choices = data.get("choices", [])
+                results: List[VLLMCompletion] = []
+                for ch in choices:
+                    text = ch.get("text", "")
+                    # OpenAI-style logprobs payload
+                    lp = ch.get("logprobs")
+                    token_logprobs: Optional[List[float]] = None
+                    if isinstance(lp, dict) and isinstance(lp.get("token_logprobs"), list):
+                        # Only completion tokens are included (no prompt echo)
+                        token_logprobs = [
+                            float(x) if x is not None else 0.0 for x in lp["token_logprobs"]
+                        ]
+                    results.append(VLLMCompletion(text=text, token_logprobs=token_logprobs))
+                return results
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                logger.warning(f"vLLM request failed (attempt {attempt+1}): {e}")
+        # Exhausted retries
+        raise RuntimeError(f"vLLM generation failed: {last_error}")
+
+

--- a/grail/shared/constants.py
+++ b/grail/shared/constants.py
@@ -18,6 +18,13 @@ WINDOW_LENGTH = 30
 MODEL_NAME = os.getenv("GRAIL_MODEL_NAME", "Qwen/Qwen3-4B-Instruct-2507")
 LAYER_INDEX = -1
 
+# Inference backend selection
+INFERENCE_BACKEND = os.getenv("INFERENCE_BACKEND", "hf").lower()
+VLLM_BASE_URL = os.getenv("VLLM_BASE_URL", "")
+VLLM_MODEL = os.getenv("VLLM_MODEL", "Qwen/Qwen3-4B-Instruct-2507")
+VLLM_TIMEOUT_S = float(os.getenv("VLLM_TIMEOUT_S", "30"))
+VLLM_MAX_RETRIES = int(os.getenv("VLLM_MAX_RETRIES", "2"))
+
 # ────────────────  LOGGING  ────────────────
 
 TRACE = 5

--- a/scripts/benchmark_vllm.py
+++ b/scripts/benchmark_vllm.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Benchmark vLLM vs HF generation for GRAIL miner defaults.
+
+- No flags required; uses env defaults from grail/shared/constants.py
+- Renders SAT prompt via the miner's chat template
+- Uses env-based backend selection (INFERENCE_BACKEND, VLLM_*)
+- Measures GRPO-style multi-rollouts (n=GRAIL_ROLLOUTS_PER_PROBLEM)
+- Also runs a single HF forward pass to estimate proof overhead
+
+Run:
+  uv run python scripts/benchmark_vllm.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+from typing import Any, List
+
+import torch
+
+from grail.grail import dot_mod_q, r_vec_from_randomness  # proof math
+from grail.shared.constants import (
+    MODEL_NAME,
+    MAX_NEW_TOKENS,
+    ROLLOUTS_PER_PROBLEM,
+    VLLM_BASE_URL,
+    VLLM_MODEL,
+    VLLM_TIMEOUT_S,
+    VLLM_MAX_RETRIES,
+)
+from grail.mining.rollout_generator import _build_qwen_chat_template, SYSTEM_PROMPT, REASONING_START
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("benchmark")
+
+
+def build_prompt(tokenizer: Any, problem_text: str) -> str:
+    try:
+        tpl = _build_qwen_chat_template(SYSTEM_PROMPT, REASONING_START)
+        if getattr(tokenizer, "chat_template", None) != tpl:
+            tokenizer.chat_template = tpl
+    except Exception:
+        pass
+    messages = [{"role": "user", "content": problem_text}]
+    return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+
+def fake_sat_problem(seed: str = "bench-seed", num_vars: int = 6, num_clauses: int = 12) -> str:
+    # Minimal SAT text to exercise the miner prompt path (does not validate)
+    lines = [f"SAT Problem (seed: {seed[:8]}...):", f"Variables: {num_vars}", "Clauses:"]
+    for i in range(num_clauses):
+        lines.append(f"  (x1 OR NOT x2 OR x3)")
+    instr = (
+        "Provide your final assignment between <SOLUTION></SOLUTION> as "
+        "space-separated 0/1 values for x1..xN (e.g., <SOLUTION>0 1 0 1</SOLUTION>).\n"
+    )
+    return "\n".join(["SAT Problem:", "\n".join(lines), instr])
+
+
+def run_vllm(prompt: str, n: int) -> List[str]:
+    from grail.inference.vllm_client import VLLMClient
+
+    client = VLLMClient(
+        base_url=VLLM_BASE_URL,
+        model=(VLLM_MODEL or None),
+        timeout=float(VLLM_TIMEOUT_S),
+        max_retries=int(VLLM_MAX_RETRIES),
+    )
+    comps = client.generate(
+        prompt,
+        n=n,
+        max_tokens=int(MAX_NEW_TOKENS),
+        temperature=0.7,
+        top_p=0.95,
+        top_k=50,
+        repetition_penalty=1.1,
+        stop=None,
+        ignore_eos=False,
+    )
+    return [c.text for c in comps]
+
+
+def run_hf(model: Any, tokenizer: Any, prompt: str, n: int) -> List[str]:
+    # Sequential HF generations to mimic miner fallback
+    outputs: List[str] = []
+    tok = tokenizer(prompt, return_tensors="pt", return_attention_mask=True)
+    input_ids = tok.input_ids.to(model.device)
+    attn = tok.attention_mask.to(model.device)
+    for _ in range(n):
+        with torch.inference_mode():
+            outs = model.generate(
+                input_ids,
+                attention_mask=attn,
+                max_new_tokens=int(MAX_NEW_TOKENS),
+                temperature=0.7,
+                do_sample=True,
+                top_p=0.95,
+                top_k=50,
+                repetition_penalty=1.1,
+                pad_token_id=tokenizer.eos_token_id,
+                eos_token_id=tokenizer.eos_token_id,
+                return_dict_in_generate=True,
+            )
+        seq = outs.sequences[0].tolist()
+        prompt_len = int(input_ids.shape[1])
+        completion_ids = seq[prompt_len:]
+        text = tokenizer.decode(completion_ids, skip_special_tokens=True)
+        outputs.append(text)
+    return outputs
+
+
+def maybe_proof_pass(model: Any, tokenizer: Any, prompt: str, completions: List[str]) -> float:
+    # Estimate time/VRAM for one proof forward pass using the longest completion
+    tok = tokenizer(prompt, return_tensors="pt")
+    prefix = tok.input_ids[0].tolist()
+    comp = max(completions, key=lambda t: len(t)) if completions else ""
+    comp_ids = tokenizer(comp, return_tensors="pt", add_special_tokens=False).input_ids[0].tolist()
+    all_ids = prefix + comp_ids
+    randomness_hex = "deadbeef" * 8
+    r_vec = r_vec_from_randomness(randomness_hex, getattr(model.config, "hidden_size", 4096))
+    start = time.time()
+    with torch.inference_mode():
+        token_tensor = torch.tensor([all_ids], dtype=torch.long, device=model.device)
+        outs = model(token_tensor, output_hidden_states=True)
+        h_layer = outs.hidden_states[-1][0]
+        _svals = [dot_mod_q(h_layer[pos], r_vec) for pos in range(min(len(all_ids), h_layer.size(0)))]
+    elapsed = time.time() - start
+    return elapsed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark vLLM vs HF miner defaults")
+    # Keep defaults fixed to simplify usage per request
+    args = parser.parse_args([])
+
+    # Load base model/tokenizer via Prover (no wallet needed here, but Prover enforces one)
+    # Workaround: create a dummy-like wallet by bypassing Prover; load directly instead.
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = (
+        AutoModelForCausalLM.from_pretrained(MODEL_NAME, use_safetensors=True)
+        .to(torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+        .eval()
+    )
+
+    n = int(ROLLOUTS_PER_PROBLEM)
+    problems = 2  # fixed per request
+    logger.info(f"Benchmarking both backends | model={MODEL_NAME} n={n} max_new_tokens={MAX_NEW_TOKENS}")
+
+    results = {}
+
+    # vLLM backend
+    if VLLM_BASE_URL:
+        v_gen_times = []
+        v_proof_times = []
+        v_total_comps = 0
+        v_start = time.time()
+        for i in range(problems):
+            sat_text = fake_sat_problem(seed=f"bench-{i}")
+            prompt = build_prompt(tokenizer, sat_text)
+            t0 = time.time()
+            try:
+                outs = run_vllm(prompt, n)
+            except Exception as e:
+                logger.warning(f"vLLM failed on group {i+1}: {e}")
+                outs = []
+            dt = time.time() - t0
+            v_gen_times.append(dt)
+            v_total_comps += len(outs)
+            proof_dt = maybe_proof_pass(model, tokenizer, prompt, outs)
+            v_proof_times.append(proof_dt)
+        v_total_time = time.time() - v_start
+        v_rps_gen = v_total_comps / sum(v_gen_times) if sum(v_gen_times) > 0 else 0.0
+        v_rps_e2e = v_total_comps / (sum(v_gen_times) + sum(v_proof_times)) if (sum(v_gen_times) + sum(v_proof_times)) > 0 else 0.0
+        results["vllm"] = {
+            "gen_times": v_gen_times,
+            "proof_times": v_proof_times,
+            "total_comps": v_total_comps,
+            "total_time": v_total_time,
+            "rps_gen": v_rps_gen,
+            "rps_e2e": v_rps_e2e,
+        }
+    else:
+        logger.info("VLLM_BASE_URL not set; skipping vLLM backend")
+
+    # HF backend
+    h_gen_times = []
+    h_proof_times = []
+    h_total_comps = 0
+    h_start = time.time()
+    for i in range(problems):
+        sat_text = fake_sat_problem(seed=f"bench-{i}")
+        prompt = build_prompt(tokenizer, sat_text)
+        t0 = time.time()
+        outs = run_hf(model, tokenizer, prompt, n)
+        dt = time.time() - t0
+        h_gen_times.append(dt)
+        h_total_comps += len(outs)
+        proof_dt = maybe_proof_pass(model, tokenizer, prompt, outs)
+        h_proof_times.append(proof_dt)
+    h_total_time = time.time() - h_start
+    h_rps_gen = h_total_comps / sum(h_gen_times) if sum(h_gen_times) > 0 else 0.0
+    h_rps_e2e = h_total_comps / (sum(h_gen_times) + sum(h_proof_times)) if (sum(h_gen_times) + sum(h_proof_times)) > 0 else 0.0
+    results["hf"] = {
+        "gen_times": h_gen_times,
+        "proof_times": h_proof_times,
+        "total_comps": h_total_comps,
+        "total_time": h_total_time,
+        "rps_gen": h_rps_gen,
+        "rps_e2e": h_rps_e2e,
+    }
+
+    # Print comparison
+    logger.info("\n=== Detailed per-group timings ===")
+    for i in range(problems):
+        vg = results.get("vllm", {}).get("gen_times", [None] * problems)[i] if "vllm" in results else None
+        vp = results.get("vllm", {}).get("proof_times", [None] * problems)[i] if "vllm" in results else None
+        hg = results["hf"]["gen_times"][i]
+        hp = results["hf"]["proof_times"][i]
+        if vg is not None:
+            logger.info(
+                f"group {i+1}: vLLM gen={vg:.3f}s proof={vp:.3f}s e2e={(vg + vp):.3f}s | HF gen={hg:.3f}s proof={hp:.3f}s e2e={(hg + hp):.3f}s"
+            )
+        else:
+            logger.info(
+                f"group {i+1}: HF gen={hg:.3f}s proof={hp:.3f}s e2e={(hg + hp):.3f}s (vLLM skipped)"
+            )
+
+    logger.info("\n=== Summary ===")
+    if "vllm" in results:
+        r = results["vllm"]
+        logger.info(
+            f"vLLM: {r['total_comps']} comps | gen_sum={sum(r['gen_times']):.3f}s proof_sum={sum(r['proof_times']):.3f}s "
+            f"e2e_sum={(sum(r['gen_times']) + sum(r['proof_times'])):.3f}s | gen_rps={r['rps_gen']:.2f} e2e_rps={r['rps_e2e']:.2f}"
+        )
+    r = results["hf"]
+    logger.info(
+        f"HF  : {r['total_comps']} comps | gen_sum={sum(r['gen_times']):.3f}s proof_sum={sum(r['proof_times']):.3f}s "
+        f"e2e_sum={(sum(r['gen_times']) + sum(r['proof_times'])):.3f}s | gen_rps={r['rps_gen']:.2f} e2e_rps={r['rps_e2e']:.2f}"
+    )
+
+
+if __name__ == "__main__":
+    main()
+
+


### PR DESCRIPTION
feat(miner): vLLM backend for GRPO (EOS termination, logprobs fallback); + benchmark

Description
Swaps HF model.generate in the miner for a vLLM backend with batched n‑completions per prompt, preserving parity and validator compatibility.
Keeps the existing Qwen chat template; we render with the tokenizer, send a plain prompt to vLLM, and re‑tokenize completion text for proofs/packing.
Sampling matches miner defaults (temperature=0.7, top_p=0.95, top_k=50, repetition_penalty=1.1, max_new_tokens=GRAIL_MAX_NEW_TOKENS). Requests use EOS termination (ignore_eos=false) to mirror HF behavior.
GRAIL proof path unchanged: one HF forward computes s_vals and commit‑binding. 
Adds a small OpenAI‑style vLLM client and an opt‑in benchmark to compare vLLM vs HF under miner defaults.

Why vLLM serve?
Simple ops, stable batching via n, isolates CUDA mem from miner, and avoids tight coupling to vLLM internals (vs vllm.LLM/AsyncLLMEngine).

If GPU memory is tight, reduce vLLM --gpu-memory-utilization so the proof pass still fits. 

Performance
~4× E2E throughput over HF on A100; successes/mean rewards consistent with HF when EOS termination used and server config doesn’t override per-request knobs.

Backwards compatibility
HF path unchanged when INFERENCE_BACKEND=hf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional vLLM inference backend with environment-based configuration (backend selector, base URL, model, timeout, retries).
  - Faster rollout generation via batch completions when using vLLM, with automatic fallback to the existing path if unavailable.
  - Benchmarking script to compare vLLM and Hugging Face backends, reporting generation and end-to-end performance.

- Documentation
  - Updated miner setup guide: streamlined environment steps and added an optional vLLM workflow with server startup instructions.
  - Quick Start now references selecting vLLM or Hugging Face backends alongside wallet/R2 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->