### PR TITLE
refactor: add minimal neurons to replace bulky CLI files later on 

### DIFF
--- a/docs/architecture/neuron-architecture.md
+++ b/docs/architecture/neuron-architecture.md
@@ -1,0 +1,303 @@
+## GRAIL Neuron Architecture and Incremental Refactor Plan
+
+### Purpose
+This document defines a simple, neuron-based architecture for GRAIL that:
+- Preserves the current behavior of miner, validator, and (future) trainer
+- Improves maintainability and testability with minimal churn
+- Aligns with Bittensor practices and sound software engineering principles
+
+It also outlines the incremental refactor plan and the target repository structure.
+
+---
+
+## First principles and requirements
+
+### Functional (Bittensor)
+- Deterministic, window-aligned processing and safe throttling of on-chain `set_weights`
+- Robust subtensor interactions with timeouts/retries/backoff
+- Reliable object-storage I/O for uploads/downloads
+- HF auth/usage for datasets and models
+- GPU-safe operation where applicable (eval mode; no-grad; bounded memory)
+
+### Non-functional (SE best practices)
+- Clear lifecycles for long-running processes (start/stop/health)
+- Separation of concerns: domain logic vs orchestration vs infrastructure
+- Typed public interfaces; explicit configuration; structured logging
+- Minimal dependencies; consistent model handling
+- Easy unit/integration testing; incremental, low-risk changes
+
+---
+
+## Architecture overview
+
+The architecture is organized into layers:
+
+- Neurons (process lifecycle)
+  - BaseNeuron lifecycle (signal handling, stop_event, optional window change event)
+  - MinerNeuron, ValidatorNeuron, TrainerNeuron compose services and run forever loops
+
+- Services (orchestration)
+  - Mining: problem selection → rollout generation → packaging → upload
+  - Validation: discovery → dedup → verify → score → publish/weights
+  - Training: fetch valid data → train → save/checkpoint
+
+- Protocol (pure logic)
+  - Prover/Verifier, commitments, challenges, signatures
+  - No I/O; deterministic, testable code
+
+- Model provider
+  - Centralized tokenizer/model initialization (dtype/device, pad token, chat templates)
+
+- Infrastructure
+  - Subtensor (network) adapters, chain/credential management, drand, object storage
+
+- CLI
+  - Thin Typer commands that parse options and start the appropriate neuron
+
+- Monitoring
+  - Backend-agnostic manager (e.g., Weights & Biases) with consistent context and metrics
+
+---
+
+## Neuron layer
+
+### BaseNeuron (slim, shared)
+- Responsibilities:
+  - Install signal handlers
+  - Maintain a shared `stop_event`
+  - Optionally maintain `current_block` and `current_window` and an `asyncio.Event` (window_changed)
+  - Provide `wait_until_window()` helper
+  - Clean shutdown for background tasks/threads
+
+- Optional extension:
+  - Replace polling with a block-header subscription thread when needed
+
+### Role neurons
+- MinerNeuron
+  - Window-driven rollout generation and uploads
+- ValidatorNeuron
+  - Window-driven discovery, verification, scoring, and weight submission (throttled)
+- TrainerNeuron (future)
+  - Window-driven training cycles and checkpoint uploads
+  - Optional profiler hooks
+
+Neurons should be very thin: they should host lifecycle and call into role-specific services.
+
+---
+
+## Services layer (extraction target)
+
+- Mining service
+  - Orchestrates window loop, uses rollout generator, packages proofs, uploads
+
+- Validation service
+  - Orchestrates window loop, uses copycat/dedup, verifier, scoring, publishing and on-chain weights
+
+- Training service (later)
+  - Pulls validated data, runs trainer, and uploads future-window checkpoints
+
+Each service remains small, focused, and testable with fakes.
+
+---
+
+## Protocol layer (split target)
+- Prover/Verifier (model-bound proof logic)
+- Commitments/Challenges/Signatures
+- Deterministic; no I/O; unit-test friendly
+
+---
+
+## Model provider
+- One place to load `AutoTokenizer` and `AutoModelForCausalLM` with:
+  - Device/dtype policy
+  - Pad token handling
+  - Chat template setup
+- Ensures consistency across miner, validator, trainer
+
+---
+
+## Infrastructure
+- Network/subtensor: creation and (optional) header subscription helper with backoff
+- Chain manager + credential management
+- Drand client
+- Object storage I/O (read/write; chunking; retries)
+
+---
+
+## CLI
+- Maintain Typer UX; CLI commands become thin wrappers that construct and run neurons
+
+---
+
+## Monitoring
+- Uniform run contexts and namespaces (uid/netuid/block/window)
+- Minimal required metrics; consistent names across roles
+
+---
+
+## Design tradeoffs and decisions
+
+### Layering depth
+- Tradeoff: Deeper layers → cleaner separation but more files; shallower → faster to change but more entanglement
+- Decision: Stage 1 introduces Neurons only; Stage 2 extracts Services/Protocol/Model Provider
+
+### Window handling: polling vs subscription
+- Tradeoff: Subscription offers low latency but adds complexity; polling is simple and sufficient at 12s blocks
+- Decision: Start with polling; add a subscription thread only when needed
+
+### Central model provider
+- Tradeoff: Centralization adds indirection; reduces config drift and subtle bugs
+- Decision: Add in Stage 2, keep interfaces small and explicit
+
+### Axon/Dendrite
+- Tradeoff: Powerful but increases surface area and ops complexity
+- Decision: Defer; neuron lifecycle leaves the door open
+
+### Repo granularity
+- Tradeoff: Many micro-packages vs pragmatic few
+- Decision: Add only `neurons/` in Stage 1; expand to `services/`, `protocol/`, `model/` in Stage 2
+
+### Import stability vs clarity
+- Tradeoff: Moving files breaks imports; re-exports hide structure
+- Decision: Use re-exports during migration; remove once downstream code is updated
+
+---
+
+## Target repository structure
+
+### Stage 1 (minimal change; add neurons only)
+- Behavior remains identical. Neurons delegate to existing code.
+
+```
+grail/
+  cli/
+    __init__.py
+    mine.py                 # existing
+    validate.py             # existing
+    train.py                # existing (WIP)
+  neurons/
+    __init__.py
+    base.py                 # lifecycle (signals, stop_event, optional window_changed)
+    miner.py                # wraps current mining loop
+    validator.py            # wraps current validation loop
+    trainer.py              # scaffolding for future training loop
+  environments/
+  infrastructure/
+  monitoring/
+  shared/
+  mining/
+  validation/
+  grail.py                  # legacy protocol (to be split later)
+  # No other moves in Stage 1
+```
+
+### Stage 2 (clear boundaries; optional re-exports for stability)
+- Extract orchestration into services; split protocol; centralize model handling.
+
+```
+grail/
+  cli/
+    mine.py                 # instantiate MinerNeuron().main()
+    validate.py             # instantiate ValidatorNeuron().main()
+    train.py                # instantiate TrainerNeuron().main()
+  neurons/
+    base.py
+    miner.py
+    validator.py
+    trainer.py
+    health.py               # optional health/readiness utilities
+  services/
+    mining/
+      service.py            # outer loop orchestration
+      pipeline.py           # problem → generate → package → upload
+    validation/
+      service.py            # outer loop orchestration
+      pipeline.py           # discover → dedup → verify → score → publish
+      dedup.py              # wraps validation/copycat.py
+      scoring.py
+    training/
+      service.py
+      pipeline.py
+  protocol/
+    prover.py
+    verifier.py
+    commitments.py
+    challenges.py
+    signatures.py
+    __init__.py             # re-export for import stability
+  model/
+    provider.py             # tokenizer/model factory
+    hf_compat.py            # move/re-export if needed
+  environments/
+  infrastructure/
+    drand.py                # single source of truth (dedupe if needed)
+  shared/
+    logging.py              # single logging helper
+    constants.py, types.py, schemas.py, subnet.py
+  monitoring/
+    manager.py, base.py, backends/
+```
+
+---
+
+## Incremental refactor plan
+
+### Stage 1 (neurons only; no behavior change)
+- Add `neurons/` with `base.py`, `miner.py`, `validator.py`, `trainer.py`
+- Keep CLI logic intact; neurons call existing functions
+- Run linter/tests; ensure zero regressions
+
+### Stage 2 (flip CLI to neurons)
+- Update Typer commands to instantiate and run neurons
+- Maintain existing flags and environment variables
+
+### Stage 3 (extract services/protocol/model provider and consolidate duplicates)
+- Move validation/mining loops to `services/`
+- Split `grail/grail.py` into `protocol/` modules with re-exports
+- Add `model/provider.py`; migrate Prover/Verifier
+- Consolidate logging and drand duplicates
+- Keep re-exports temporarily; remove later
+
+Rollback: Each stage is independently reversible.
+
+---
+
+## Coding and dependency standards
+
+- Package management: `uv`; pin versions in `pyproject.toml`; no manual lockfile edits
+- Python: 3.9–3.11
+- Allowed deps: torch, transformers, safetensors, numpy, typer, rich, python-dotenv, requests, aiobotocore/botocore, bittensor, huggingface_hub, datasets
+- Style: PEP 8; max line length 100; typed public APIs; no wildcard imports
+- Logging: `logging.getLogger(__name__)`; no prints; no secret logging
+- Concurrency: `asyncio` for I/O; no event-loop blocking; timeouts on network calls
+- Security: HTTPS, environment-based secrets loading, safetensors for model weights
+
+---
+
+## Testing approach
+
+- Unit tests at the Protocol and Services layers (pure logic; fakes for infra)
+- Integration tests for neuron lifecycles with stubbed network/storage
+- Deterministic tests where feasible; seed RNGs when needed
+
+---
+
+## Bittensor-specific guidance
+
+- Refresh metagraph only when block increases; cache by block number
+- Throttle weight submissions (e.g., one per 360 blocks)
+- Structured metrics with uid/netuid/block/window context
+- Use eval mode and no-grad for validator/miner; manage GPU memory proactively
+
+---
+
+## Glossary
+
+- Neuron: Long-running process (miner/validator/trainer) with a clean lifecycle
+- Service: Orchestrated steps for a role (e.g., validation pipeline)
+- Protocol: Model-proof logic (Prover/Verifier, commitments)
+- Model provider: Centralized factory for tokenizer/model setup
+
+---
+
+

--- a/grail/cli/mine.py
+++ b/grail/cli/mine.py
@@ -8,9 +8,7 @@ import logging
 import math
 import os
 import time
-import traceback
 from dataclasses import dataclass
-from types import SimpleNamespace
 from typing import Any, Optional
 
 import bittensor as bt
@@ -19,15 +17,10 @@ import typer
 
 from ..environments import SATRolloutGenerator, generate_sat_problem
 from ..grail import Prover, derive_canonical_sat, sign_commit_binding
-from ..infrastructure.chain import GrailChainManager
 from ..infrastructure.comms import sink_window_inferences
-from ..infrastructure.credentials import load_r2_credentials
 from ..infrastructure.drand import get_drand_beacon
 from ..infrastructure.network import create_subtensor
-from ..monitoring import get_monitoring_manager
-from ..monitoring.config import MonitoringConfig
-from ..shared.constants import LAYER_INDEX, MODEL_NAME, ROLLOUTS_PER_PROBLEM, WINDOW_LENGTH
-from ..shared.subnet import get_own_uid_on_subnet
+from ..shared.constants import LAYER_INDEX, ROLLOUTS_PER_PROBLEM, WINDOW_LENGTH
 from . import console
 
 # --------------------------------------------------------------------------- #
@@ -654,7 +647,7 @@ async def generate_rollouts_for_window(
                 mean_reward,
             )
 
-            if problem_count % 10 == 0:
+            if problem_count % 2 == 0:
                 elapsed = time.time() - start_time
                 rollouts_per_sec = (len(inferences) / elapsed) if elapsed > 0 else 0
                 logger.info(
@@ -783,145 +776,12 @@ def mine(
 ) -> None:
     """Mine GRPO rollouts for SAT problems using GRAIL proofs.
 
-    This is the main mining entry point that:
-    - Loads the model and initializes the prover
-    - Connects to Bittensor and object storage
-    - Generates rollouts within time windows
-    - Uploads validated rollouts for validator consumption
-
-    Args:
-        use_drand: Whether to include drand randomness in challenges.
+    Stage 2: delegate to MinerNeuron lifecycle to keep behavior identical
+    while standardizing the long-running process management.
     """
-    coldkey = get_conf("BT_WALLET_COLD", "default")
-    hotkey = get_conf("BT_WALLET_HOT", "default")
-    wallet = bt.wallet(name=coldkey, hotkey=hotkey)
+    from ..neurons import MinerNeuron
 
-    # Initialize model and prover
-    logger.info(f"🔑 Miner hotkey: {wallet.hotkey.ss58_address}")
-    logger.info(f"Loading base model: {MODEL_NAME}")
-
-    # Use wallet for secure GRAIL proof signatures
-    prover = Prover(model_name=MODEL_NAME, wallet=wallet)
-
-    async def _run() -> None:
-        subtensor = None
-        last_window_start = -1
-        timers = MiningTimers()
-
-        # Load R2 credentials
-        try:
-            credentials = load_r2_credentials()
-            logger.info("✅ Loaded R2 credentials")
-        except Exception as e:
-            logger.error(f"Failed to load R2 credentials: {e}")
-            raise
-
-        # Initialize chain manager for credential commitments
-        config = SimpleNamespace(netuid=int(get_conf("BT_NETUID", get_conf("NETUID", 200))))
-        chain_manager = GrailChainManager(config, wallet, credentials)
-        await chain_manager.initialize()
-        logger.info("✅ Initialized chain manager and committed read credentials")
-
-        # Initialize monitoring for mining operations
-        monitor = get_monitoring_manager()
-        if monitor:
-            mining_config = MonitoringConfig.for_mining(wallet.name)
-            try:
-                subtensor_for_uid = await get_subtensor()
-            except Exception:
-                subtensor_for_uid = None
-            uid = None
-            if subtensor_for_uid is not None:
-                uid = await get_own_uid_on_subnet(subtensor_for_uid, 81, wallet.hotkey.ss58_address)
-            run_name = f"miner-{uid}" if uid is not None else f"mining_{wallet.name}"
-            run_id = await monitor.start_run(run_name, mining_config.get("hyperparameters", {}))
-            logger.info(f"Started monitoring run: {run_id} (name={run_name})")
-
-        while True:
-            try:
-                global HEARTBEAT
-                HEARTBEAT = time.monotonic()
-                if subtensor is None:
-                    subtensor = await get_subtensor()
-
-                current_block = await subtensor.get_current_block()
-                window_start = calculate_window_start(current_block)
-
-                if window_start <= last_window_start:
-                    await asyncio.sleep(2)
-                    continue
-
-                logger.info(f"🚀 Using base model for window {window_start}")
-                logger.info(
-                    f"🔥 Starting inference generation for window "
-                    f"{window_start}-{window_start + WINDOW_LENGTH - 1}"
-                )
-
-                if not await has_time_for_next_generation(subtensor, timers, window_start):
-                    last_window_start = window_start
-                    await asyncio.sleep(5)
-                    continue
-
-                window_block_hash, combined_randomness = await get_window_randomness(
-                    subtensor,
-                    window_start,
-                    use_drand,
-                )
-
-                inferences = await generate_rollouts_for_window(
-                    wallet,
-                    prover,
-                    subtensor,
-                    window_start,
-                    window_block_hash,
-                    combined_randomness,
-                    timers,
-                    monitor,
-                    use_drand,
-                )
-
-                if inferences:
-                    logger.info(
-                        f"📤 Uploading {len(inferences)} rollouts to R2 "
-                        f"for window {window_start}..."
-                    )
-                    try:
-                        upload_duration = await upload_inferences_with_metrics(
-                            wallet, window_start, inferences, credentials, monitor
-                        )
-                        timers.update_upload_time_ema(upload_duration)
-                        logger.info(
-                            f"✅ Successfully uploaded window {window_start} "
-                            f"with {len(inferences)} rollouts"
-                        )
-                        HEARTBEAT = time.monotonic()
-                        if monitor:
-                            await monitor.log_counter("mining.successful_uploads")
-                            await monitor.log_gauge("mining.uploaded_rollouts", len(inferences))
-                    except Exception as e:
-                        logger.error(f"❌ Failed to upload window {window_start}: {e}")
-                        logger.error(traceback.format_exc())
-                        if monitor:
-                            await monitor.log_counter("mining.failed_uploads")
-                else:
-                    logger.warning(f"No inferences generated for window {window_start}")
-                    if monitor:
-                        await monitor.log_counter("mining.empty_windows")
-
-                last_window_start = window_start
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                traceback.print_exc()
-                logger.error(f"Error in miner loop: {e}. Continuing ...")
-                subtensor = None
-                await asyncio.sleep(10)
-                continue
-
-    async def _main() -> None:
-        await asyncio.gather(_run(), watchdog())
-
-    asyncio.run(_main())
+    asyncio.run(MinerNeuron(use_drand=use_drand).main())
 
 
 # --------------------------------------------------------------------------- #

--- a/grail/neurons/__init__.py
+++ b/grail/neurons/__init__.py
@@ -1,0 +1,13 @@
+"""Neuron lifecycle abstractions for miner, validator, and trainer.
+
+Stage 1 introduces a minimal neuron layer without changing runtime behavior.
+Neurons delegate to existing CLI entry points; later stages will extract
+orchestration into services and flip CLI to construct and run neurons.
+"""
+
+from .base import BaseNeuron
+from .miner import MinerNeuron
+from .trainer import TrainerNeuron
+from .validator import ValidatorNeuron
+
+__all__ = ["BaseNeuron", "MinerNeuron", "ValidatorNeuron", "TrainerNeuron"]

--- a/grail/neurons/base.py
+++ b/grail/neurons/base.py
@@ -1,0 +1,121 @@
+"""Base neuron lifecycle for long-running GRAIL processes.
+
+Provides:
+- Signal-safe start/stop handling (SIGINT, SIGTERM)
+- A shared stop_event to coordinate shutdown
+- Optional window change signaling for future event-driven orchestration
+
+Stage 1 keeps this class minimal and self-contained. Subclasses should
+override `run()` and may push background tasks/threads into the provided
+registries for coordinated teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BaseNeuron:
+    """Shared lifecycle for miner, validator, and trainer neurons.
+
+    Subclasses should override `run()` and should not block the event loop
+    on network/IO operations. Use asyncio with timeouts for reliability.
+    """
+
+    def __init__(self) -> None:
+        # Cooperative shutdown signal for all async logic
+        self.stop_event: asyncio.Event = asyncio.Event()
+
+        # Background bookkeeping for structured teardown
+        self._bg_tasks: set[asyncio.Task] = set()
+        self._threads: list[threading.Thread] = []
+
+        # Optional window-tracking primitives (set by subclasses if needed)
+        self.window_changed: Optional[asyncio.Event] = None  # noqa: UP045
+        self._notify_loop: Optional[asyncio.AbstractEventLoop] = None  # noqa: UP045
+        self.current_block: int = 0
+        self.current_window: int = 0
+
+    async def main(self) -> None:
+        """Install signal handlers, initialize optional events, and run."""
+        loop = asyncio.get_running_loop()
+        self._install_signal_handlers(loop)
+
+        # Initialize optional window signaling. Subclasses may call
+        # `self.window_changed.set()` from background listeners.
+        self.window_changed = asyncio.Event()
+        self._notify_loop = loop
+
+        try:
+            await self.run()
+        finally:
+            # Ensure graceful shutdown even if run() completes normally
+            if not self.stop_event.is_set():
+                await self._shutdown(signal.SIGTERM)
+
+    async def run(self) -> None:
+        """Entry point for subclasses to implement their main loop."""
+        raise NotImplementedError
+
+    async def wait_until_window(self, target_window: int) -> None:
+        """Block until `current_window` >= target_window or shutdown.
+
+        Uses the optional `window_changed` event if set; otherwise, polls
+        at a low cadence. Subclasses are responsible for updating
+        `current_window`.
+        """
+        evt = self.window_changed
+        # Clear a stale signal so a prior set() doesn't wake immediately
+        if evt is not None and evt.is_set():
+            evt.clear()
+
+        while not self.stop_event.is_set():
+            if self.current_window >= target_window:
+                return
+            if evt is None:
+                await asyncio.sleep(0.5)
+            else:
+                await evt.wait()
+                evt.clear()
+
+    def _install_signal_handlers(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Register handlers to trigger cooperative shutdown."""
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(self._shutdown(s)))
+
+    async def _shutdown(self, sig: signal.Signals) -> None:
+        """Set stop flag, cancel tasks, and join threads.
+
+        This function is idempotent and safe to call multiple times.
+        """
+        try:
+            logger.warning("Shutting down due to signal: %s", sig.name)
+        except Exception:
+            pass
+
+        if self.stop_event.is_set():
+            # Already shutting down
+            return
+        self.stop_event.set()
+
+        # Cancel and await background tasks
+        for task in list(self._bg_tasks):
+            task.cancel()
+        if self._bg_tasks:
+            await asyncio.gather(*self._bg_tasks, return_exceptions=True)
+
+        # Join helper threads
+        for th in self._threads:
+            try:
+                th.join(timeout=2)
+            except Exception:
+                pass
+
+        # Allow log buffers to flush
+        await asyncio.sleep(0.1)

--- a/grail/neurons/miner.py
+++ b/grail/neurons/miner.py
@@ -1,12 +1,30 @@
-"""Miner neuron wrapper.
-
-Stage 1 delegates to the existing CLI entry to avoid behavior changes.
-In later stages, this neuron will orchestrate the mining service directly.
-"""
-
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
+import traceback
+from types import SimpleNamespace
+
+import bittensor as bt
+
+import grail.cli.mine as cli_mine
+from grail.cli.mine import (
+    MiningTimers,
+    generate_rollouts_for_window,
+    get_conf,
+    get_subtensor,
+    get_window_randomness,
+    has_time_for_next_generation,
+    upload_inferences_with_metrics,
+)
+from grail.grail import Prover
+from grail.infrastructure.chain import GrailChainManager
+from grail.infrastructure.credentials import load_r2_credentials
+from grail.monitoring import get_monitoring_manager
+from grail.monitoring.config import MonitoringConfig
+from grail.shared.constants import MODEL_NAME, WINDOW_LENGTH
+from grail.shared.subnet import get_own_uid_on_subnet
 
 from .base import BaseNeuron
 
@@ -21,7 +39,134 @@ class MinerNeuron(BaseNeuron):
         self.use_drand = use_drand
 
     async def run(self) -> None:
-        # Delegate to existing CLI entry for now (no behavior change in Stage 1)
-        from grail.cli.mine import mine
+        """Main mining loop mirrored from the CLI implementation."""
+        coldkey = get_conf("BT_WALLET_COLD", "default")
+        hotkey = get_conf("BT_WALLET_HOT", "default")
+        wallet = bt.wallet(name=coldkey, hotkey=hotkey)
 
-        mine(use_drand=self.use_drand)
+        # Initialize model and prover
+        logger.info(f"🔑 Miner hotkey: {wallet.hotkey.ss58_address}")
+        logger.info(f"Loading base model: {MODEL_NAME}")
+        prover = Prover(model_name=MODEL_NAME, wallet=wallet)
+
+        async def _run() -> None:
+            subtensor = None
+            last_window_start = -1
+            timers = MiningTimers()
+
+            # Load R2 credentials
+            try:
+                credentials = load_r2_credentials()
+                logger.info("✅ Loaded R2 credentials")
+            except Exception as e:
+                logger.error(f"Failed to load R2 credentials: {e}")
+                raise
+
+            # Initialize chain manager for credential commitments
+            config = SimpleNamespace(netuid=int(get_conf("BT_NETUID", get_conf("NETUID", 200))))
+            chain_manager = GrailChainManager(config, wallet, credentials)
+            await chain_manager.initialize()
+            logger.info("✅ Initialized chain manager and committed read credentials")
+
+            # Initialize monitoring for mining operations
+            monitor = get_monitoring_manager()
+            if monitor:
+                mining_config = MonitoringConfig.for_mining(wallet.name)
+                try:
+                    subtensor_for_uid = await get_subtensor()
+                except Exception:
+                    subtensor_for_uid = None
+                uid = None
+                if subtensor_for_uid is not None:
+                    uid = await get_own_uid_on_subnet(
+                        subtensor_for_uid, 81, wallet.hotkey.ss58_address
+                    )
+                run_name = f"miner-{uid}" if uid is not None else f"mining_{wallet.name}"
+                run_id = await monitor.start_run(run_name, mining_config.get("hyperparameters", {}))
+                logger.info(f"Started monitoring run: {run_id} (name={run_name})")
+
+            while not self.stop_event.is_set():
+                try:
+                    # Update the heartbeat used by the CLI watchdog
+                    cli_mine.HEARTBEAT = time.monotonic()
+                    if subtensor is None:
+                        subtensor = await get_subtensor()
+
+                    current_block = await subtensor.get_current_block()
+                    window_start = (current_block // WINDOW_LENGTH) * WINDOW_LENGTH
+
+                    if window_start <= last_window_start:
+                        await asyncio.sleep(2)
+                        continue
+
+                    logger.info(f"🚀 Using base model for window {window_start}")
+                    logger.info(
+                        f"🔥 Starting inference generation for window "
+                        f"{window_start}-{window_start + WINDOW_LENGTH - 1}"
+                    )
+
+                    if not await has_time_for_next_generation(subtensor, timers, window_start):
+                        last_window_start = window_start
+                        await asyncio.sleep(5)
+                        continue
+
+                    window_block_hash, combined_randomness = await get_window_randomness(
+                        subtensor,
+                        window_start,
+                        self.use_drand,
+                    )
+
+                    inferences = await generate_rollouts_for_window(
+                        wallet,
+                        prover,
+                        subtensor,
+                        window_start,
+                        window_block_hash,
+                        combined_randomness,
+                        timers,
+                        monitor,
+                        self.use_drand,
+                    )
+
+                    if inferences:
+                        logger.info(
+                            f"📤 Uploading {len(inferences)} rollouts to R2 "
+                            f"for window {window_start}..."
+                        )
+                        try:
+                            upload_duration = await upload_inferences_with_metrics(
+                                wallet, window_start, inferences, credentials, monitor
+                            )
+                            timers.update_upload_time_ema(upload_duration)
+                            logger.info(
+                                f"✅ Successfully uploaded window {window_start} "
+                                f"with {len(inferences)} rollouts"
+                            )
+                            cli_mine.HEARTBEAT = time.monotonic()
+                            if monitor:
+                                await monitor.log_counter("mining.successful_uploads")
+                                await monitor.log_gauge("mining.uploaded_rollouts", len(inferences))
+                        except Exception as e:
+                            logger.error(f"❌ Failed to upload window {window_start}: {e}")
+                            logger.error(traceback.format_exc())
+                            if monitor:
+                                await monitor.log_counter("mining.failed_uploads")
+                    else:
+                        logger.warning(f"No inferences generated for window {window_start}")
+                        if monitor:
+                            await monitor.log_counter("mining.empty_windows")
+
+                    last_window_start = window_start
+                except asyncio.CancelledError:
+                    break
+                except Exception as e:
+                    traceback.print_exc()
+                    logger.error(f"Error in miner loop: {e}. Continuing ...")
+                    subtensor = None
+                    await asyncio.sleep(10)
+                    continue
+
+        async def _main() -> None:
+            await asyncio.gather(_run(), cli_mine.watchdog())
+
+        await _main()

--- a/grail/neurons/miner.py
+++ b/grail/neurons/miner.py
@@ -1,0 +1,27 @@
+"""Miner neuron wrapper.
+
+Stage 1 delegates to the existing CLI entry to avoid behavior changes.
+In later stages, this neuron will orchestrate the mining service directly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .base import BaseNeuron
+
+logger = logging.getLogger(__name__)
+
+
+class MinerNeuron(BaseNeuron):
+    """Runs the mining loop under a unified neuron lifecycle."""
+
+    def __init__(self, use_drand: bool = True) -> None:
+        super().__init__()
+        self.use_drand = use_drand
+
+    async def run(self) -> None:
+        # Delegate to existing CLI entry for now (no behavior change in Stage 1)
+        from grail.cli.mine import mine
+
+        mine(use_drand=self.use_drand)

--- a/grail/neurons/trainer.py
+++ b/grail/neurons/trainer.py
@@ -1,0 +1,27 @@
+"""Trainer neuron wrapper.
+
+Stage 1 delegates to the existing CLI entry to avoid behavior changes.
+As training matures, this will host the training service and optional
+profiler hooks under the unified neuron lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .base import BaseNeuron
+
+logger = logging.getLogger(__name__)
+
+
+class TrainerNeuron(BaseNeuron):
+    """Runs the training loop under a unified neuron lifecycle."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    async def run(self) -> None:
+        # Delegate to existing CLI entry for now (no behavior change in Stage 1)
+        from grail.cli.train import train
+
+        train()

--- a/grail/neurons/validator.py
+++ b/grail/neurons/validator.py
@@ -1,0 +1,28 @@
+"""Validator neuron wrapper.
+
+Stage 1 delegates to the existing CLI entry to avoid behavior changes.
+In later stages, this neuron will orchestrate the validation service directly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .base import BaseNeuron
+
+logger = logging.getLogger(__name__)
+
+
+class ValidatorNeuron(BaseNeuron):
+    """Runs the validation loop under a unified neuron lifecycle."""
+
+    def __init__(self, use_drand: bool = True, test_mode: bool = False) -> None:
+        super().__init__()
+        self.use_drand = use_drand
+        self.test_mode = test_mode
+
+    async def run(self) -> None:
+        # Delegate to existing CLI entry for now (no behavior change in Stage 1)
+        from grail.cli.validate import validate
+
+        validate(use_drand=self.use_drand, test_mode=self.test_mode)

--- a/grail/neurons/validator.py
+++ b/grail/neurons/validator.py
@@ -8,6 +8,18 @@ from __future__ import annotations
 
 import logging
 
+import bittensor as bt
+
+from grail.cli.validate import (
+    _flush_all_logs,
+    _get_sat_reward_bounds,
+    _run_validation_service,
+    get_conf,
+)
+from grail.grail import Verifier
+from grail.infrastructure.comms import login_huggingface
+from grail.shared.constants import MODEL_NAME
+
 from .base import BaseNeuron
 
 logger = logging.getLogger(__name__)
@@ -22,7 +34,32 @@ class ValidatorNeuron(BaseNeuron):
         self.test_mode = test_mode
 
     async def run(self) -> None:
-        # Delegate to existing CLI entry for now (no behavior change in Stage 1)
-        from grail.cli.validate import validate
+        # Orchestrate validation using existing helpers (no behavior change).
+        logger = logging.getLogger("grail")
 
-        validate(use_drand=self.use_drand, test_mode=self.test_mode)
+        coldkey = get_conf("BT_WALLET_COLD", "default")
+        hotkey = get_conf("BT_WALLET_HOT", "default")
+        wallet = bt.wallet(name=coldkey, hotkey=hotkey)
+
+        logger.info(f"🔑 Validator hotkey: {wallet.hotkey.ss58_address}")
+        logger.info(f"Loading base model for validation: {MODEL_NAME}")
+        verifier = Verifier(model_name=MODEL_NAME)
+
+        logger.info("🤗 Logging into Hugging Face for dataset uploads...")
+        login_huggingface()
+
+        sat_reward_low, sat_reward_high = _get_sat_reward_bounds()
+
+        try:
+            await _run_validation_service(
+                wallet=wallet,
+                verifier=verifier,
+                sat_reward_low=sat_reward_low,
+                sat_reward_high=sat_reward_high,
+                use_drand=self.use_drand,
+                test_mode=self.test_mode,
+            )
+        except Exception:
+            logger.exception("Validator crashed due to unhandled exception")
+            _flush_all_logs()
+            raise


### PR DESCRIPTION
### Refactor: Introduce neuron lifecycle and flip CLI to neurons (Stages 1–2)

- Added `grail/neurons/` with `BaseNeuron`, `MinerNeuron`, `ValidatorNeuron`, `TrainerNeuron` (stub).
- `validate` and `mine` CLIs now delegate to neurons; behavior unchanged.
- Documented the refactoring approach in `docs/architecture/neuron-architecture.md` that's gonna later be used for a complete refactor. 

Why
- Clear lifecycle boundaries; prepare service extraction without breaking current flows.

Impact
- No flag or behavior changes; lint clean; tests unchanged (pre-existing failures remain).