### PR TITLE
fix(validation): directional gating for copycat detection

### DIFF
--- a/grail/validation/copycat_service.py
+++ b/grail/validation/copycat_service.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from itertools import combinations
 from typing import Any, Literal
@@ -161,7 +162,7 @@ class _PairAttribution:
 def _attribute_pair_direction(
     miner_a: str,
     miner_b: str,
-    uploads: UploadTimesByHotkey,
+    uploads: Mapping[str, float | None],
 ) -> _PairAttribution:
     """Decide which side of a violating pair is the copier.
 
@@ -206,6 +207,17 @@ class CopycatTracker:
         self.current_interval_id: int | None = None
         self.interval_pair_overlap: defaultdict[frozenset[str], int] = defaultdict(int)
         self.interval_totals: defaultdict[str, int] = defaultdict(int)
+        # Per-miner upload timestamp (S3 LastModified) archived across the
+        # current interval. Only real (non-None) timestamps are ever
+        # written. We type the value as ``float | None`` to match
+        # :data:`UploadTimesByHotkey` exactly so the map can be passed
+        # straight into ``_find_cheaters`` without a second copy or a
+        # covariant Mapping wrapper. Used for interval-scope directional
+        # attribution so a pair whose overlap accumulated across multiple
+        # windows can still be attributed when one miner is absent from
+        # the current window. See the regression test
+        # ``test_interval_attribution_survives_victim_going_offline``.
+        self.interval_upload_times: UploadTimesByHotkey = {}
 
     def reset_interval(self, interval_id: int) -> None:
         """Reset interval statistics when a new submission interval starts.
@@ -218,6 +230,7 @@ class CopycatTracker:
         self.current_interval_id = interval_id
         self.interval_pair_overlap.clear()
         self.interval_totals.clear()
+        self.interval_upload_times.clear()
 
     def ingest_window(
         self,
@@ -277,6 +290,15 @@ class CopycatTracker:
 
         for miner, submission in submissions.items():
             self.interval_totals[miner] += submission.total_rollouts
+            # Archive the most recent upload time for each miner seen in
+            # this interval. Interval-scope attribution must reference this
+            # map, not the current window's uploads, because
+            # interval_pair_overlap accumulates across windows and one of
+            # the pair may be absent from the current window. Without this
+            # archive, absent victims would cause _attribute_pair_direction
+            # to abstain and the accumulated cheat would escape gating.
+            if submission.upload_time is not None:
+                self.interval_upload_times[miner] = submission.upload_time
 
         window_cheaters, window_details = self._find_cheaters(
             pair_overlap=window_pair_overlap,
@@ -292,7 +314,7 @@ class CopycatTracker:
             threshold=COPYCAT_INTERVAL_THRESHOLD,
             scope="interval",
             window_start=window_start,
-            uploads=uploads,
+            uploads=self.interval_upload_times,
         )
 
         # Build complete pair lists (not only those exceeding threshold)
@@ -352,7 +374,7 @@ class CopycatTracker:
         threshold: float,
         scope: Literal["window", "interval"],
         window_start: int,
-        uploads: UploadTimesByHotkey,
+        uploads: Mapping[str, float | None],
     ) -> tuple[set[str], list[CopycatViolation]]:
         """Return flagged copiers and detailed violations for a given scope.
 

--- a/grail/validation/copycat_service.py
+++ b/grail/validation/copycat_service.py
@@ -51,9 +51,63 @@ COPYCAT_WINDOW_THRESHOLD = 0.05
 COPYCAT_INTERVAL_THRESHOLD = 0.03
 
 
+# Upload-time map propagated from ``MinerSampler.discover_active_miners``.
+# Values are S3 ``LastModified`` unix timestamps; ``None`` means the
+# timestamp could not be retrieved for that hotkey. Miner-supplied row
+# timestamps are NEVER stored here because they are forgeable.
+UploadTimesByHotkey = dict[str, float | None]
+
+
+@dataclass(frozen=True)
+class MinerCopycatSubmission:
+    """All per-miner state that copycat detection needs for one window.
+
+    Packaging this into a value object (rather than threading parallel
+    ``digest_counter``, ``total_rollouts``, ``upload_time`` parameters
+    through every layer from ``MinerSampler`` to ``CopycatTracker``) gives
+    us two concrete wins:
+
+    1. The public ``detect_cheaters`` API takes one argument per miner
+       instead of three, and a new copycat signal added in a later tier
+       (e.g. a ``prompt_digest_counter`` for Tier 1's cross-hotkey prompt
+       collision check) becomes a new field on this dataclass rather than
+       yet another parallel parameter plumbed through four modules.
+    2. Callers are forced to assemble all of a miner's state in one place
+       (currently :meth:`WindowProcessor.process_window`), which means
+       there is exactly one point where ``upload_time`` can be forgotten,
+       rather than four independent opportunities to drop it on the floor
+       and silently reintroduce the victim-punishment bug.
+
+    Fields:
+        digest_counter: Counter of completion-token digests as produced by
+            :func:`grail.shared.digest.compute_completion_digest`.
+        total_rollouts: Number of rollouts in the miner's submitted parquet.
+            Used as the denominator for the overlap ratio.
+        upload_time: Unix timestamp from the S3 ``LastModified`` header of
+            the parquet object, propagated from
+            ``file_exists_with_deadline``. ``None`` means the timestamp was
+            not retrievable; in that case, directional attribution for any
+            pair involving this miner abstains rather than gating the
+            wrong side. NEVER populate this from miner-supplied row data.
+    """
+
+    digest_counter: Counter[str]
+    total_rollouts: int
+    upload_time: float | None = None
+
+
 @dataclass(frozen=True)
 class CopycatViolation:
-    """Details about a detected copycat relationship between two miners."""
+    """Details about a detected copycat relationship between two miners.
+
+    When directional attribution succeeds (both miners have an S3 LastModified
+    timestamp and the timestamps differ), ``copier`` is the hotkey that
+    uploaded later and ``victim`` is the other one. Only the copier is added
+    to the cheater set for gating; the victim is left intact. When direction
+    cannot be resolved (either upload time is missing, or they are equal
+    within resolution), ``copier`` and ``victim`` are both ``None`` and the
+    pair is logged but not gated.
+    """
 
     miner_a: str
     miner_b: str
@@ -63,6 +117,80 @@ class CopycatViolation:
     threshold: float
     scope: Literal["window", "interval"]
     window_start: int
+    copier: str | None = None
+    victim: str | None = None
+
+
+@dataclass(frozen=True)
+class _PairAttribution:
+    """Result of directional attribution for a violating miner pair.
+
+    This is an internal value object; its sole purpose is to decouple the
+    "who uploaded later" decision from the "gate the copier and build a
+    violation record" logic inside :meth:`CopycatTracker._find_cheaters`.
+    Making it a named, frozen dataclass (rather than a bare tuple or inline
+    ``None`` checks) means the two downstream consumers — gating and logging
+    — read the same property rather than repeating the None-checks.
+    """
+
+    copier: str | None
+    victim: str | None
+
+    @property
+    def is_resolved(self) -> bool:
+        """True when both parties are known and distinct."""
+        return self.copier is not None and self.victim is not None
+
+    @classmethod
+    def unresolved(cls) -> _PairAttribution:
+        """Sentinel for a pair whose direction cannot be determined.
+
+        Callers MUST treat this as "log but do not gate". Returning this
+        value is how we guarantee the pre-Tier-0 victim-punishment bug
+        cannot regress: an unresolved attribution carries no hotkey to add
+        to the cheater set.
+        """
+        return cls(copier=None, victim=None)
+
+    @classmethod
+    def resolved(cls, copier: str, victim: str) -> _PairAttribution:
+        """Direction has been determined: ``copier`` uploaded after ``victim``."""
+        return cls(copier=copier, victim=victim)
+
+
+def _attribute_pair_direction(
+    miner_a: str,
+    miner_b: str,
+    uploads: UploadTimesByHotkey,
+) -> _PairAttribution:
+    """Decide which side of a violating pair is the copier.
+
+    Uses only object-store ``LastModified`` timestamps propagated from
+    ``file_exists_with_deadline`` (``grail/infrastructure/comms.py:988``).
+    Never uses miner-supplied row timestamps — those are forgeable and would
+    reintroduce the bug this module is designed to prevent.
+
+    Abstains (returns :meth:`_PairAttribution.unresolved`) when:
+
+    - either miner's upload time is unknown, or
+    - the two upload times are equal within resolution.
+
+    We prefer a missed detection over punishing a victim, so abstention is
+    the safe default whenever the signal is ambiguous.
+
+    This function is intentionally module-level and stateless so it is
+    trivially testable and so future detectors (e.g. a multi-signal variant
+    in Tier 1) can reuse it without instantiating the tracker.
+    """
+    t_a = uploads.get(miner_a)
+    t_b = uploads.get(miner_b)
+    if t_a is None or t_b is None:
+        return _PairAttribution.unresolved()
+    if t_a == t_b:
+        return _PairAttribution.unresolved()
+    if t_a > t_b:
+        return _PairAttribution.resolved(copier=miner_a, victim=miner_b)
+    return _PairAttribution.resolved(copier=miner_b, victim=miner_a)
 
 
 class CopycatTracker:
@@ -94,7 +222,7 @@ class CopycatTracker:
     def ingest_window(
         self,
         window_start: int,
-        miner_rollouts: dict[str, tuple[Counter[str], int]],
+        submissions: dict[str, MinerCopycatSubmission],
     ) -> tuple[
         set[str],
         list[CopycatViolation],
@@ -103,27 +231,37 @@ class CopycatTracker:
         list[CopycatViolation],
         list[CopycatViolation],
     ]:
-        """Ingest a window of rollouts and compute copycat cheaters.
+        """Ingest a window of submissions and compute copycat cheaters.
 
         Args:
             window_start: Window start block number (used in violation details).
-            miner_rollouts: Map of miner hotkey -> (digest_counter, total_rollouts_in_window).
+            submissions: Per-hotkey :class:`MinerCopycatSubmission` records.
+                Each submission bundles the completion-digest counter, the
+                total rollout count, and the S3 ``LastModified`` timestamp
+                for that miner. Caller is
+                :meth:`WindowProcessor.process_window`, which assembles the
+                submissions from ``MinerResults`` plus the
+                ``discover_active_miners`` upload-time map.
 
         Returns:
             Tuple of:
-            - window_cheaters: Miners flagged at the window scope
-            - window_details: Per-pair violation details for window scope
-            - interval_cheaters: Miners flagged at the interval scope
-            - interval_details: Per-pair violation details for interval scope
-            - window_all_pairs: All observed miner pairs this window
-            - interval_all_pairs: All observed miner pairs for the current interval
+            - window_cheaters: Copiers flagged at the window scope (victims not included).
+            - window_details: Per-pair violation details for window scope.
+            - interval_cheaters: Copiers flagged at the interval scope.
+            - interval_details: Per-pair violation details for interval scope.
+            - window_all_pairs: All observed miner pairs this window.
+            - interval_all_pairs: All observed miner pairs for the current interval.
         """
         window_pair_overlap: defaultdict[frozenset[str], int] = defaultdict(int)
-        window_totals = {miner: total for miner, (_, total) in miner_rollouts.items()}
+        window_totals = {miner: s.total_rollouts for miner, s in submissions.items()}
+        # Extract the upload-time view once so _find_cheaters does not need
+        # to know about MinerCopycatSubmission internals; keeps the
+        # attribution helper decoupled from the submission schema.
+        uploads: UploadTimesByHotkey = {miner: s.upload_time for miner, s in submissions.items()}
 
         digest_map: defaultdict[str, list[tuple[str, int]]] = defaultdict(list)
-        for miner, (counter, _) in miner_rollouts.items():
-            for digest, count in counter.items():
+        for miner, submission in submissions.items():
+            for digest, count in submission.digest_counter.items():
                 digest_map[digest].append((miner, count))
 
         for miners in digest_map.values():
@@ -137,8 +275,8 @@ class CopycatTracker:
                 window_pair_overlap[pair_key] += overlap
                 self.interval_pair_overlap[pair_key] += overlap
 
-        for miner, (_, total_rollouts) in miner_rollouts.items():
-            self.interval_totals[miner] += total_rollouts
+        for miner, submission in submissions.items():
+            self.interval_totals[miner] += submission.total_rollouts
 
         window_cheaters, window_details = self._find_cheaters(
             pair_overlap=window_pair_overlap,
@@ -146,6 +284,7 @@ class CopycatTracker:
             threshold=COPYCAT_WINDOW_THRESHOLD,
             scope="window",
             window_start=window_start,
+            uploads=uploads,
         )
         interval_cheaters, interval_details = self._find_cheaters(
             pair_overlap=self.interval_pair_overlap,
@@ -153,6 +292,7 @@ class CopycatTracker:
             threshold=COPYCAT_INTERVAL_THRESHOLD,
             scope="interval",
             window_start=window_start,
+            uploads=uploads,
         )
 
         # Build complete pair lists (not only those exceeding threshold)
@@ -212,15 +352,29 @@ class CopycatTracker:
         threshold: float,
         scope: Literal["window", "interval"],
         window_start: int,
+        uploads: UploadTimesByHotkey,
     ) -> tuple[set[str], list[CopycatViolation]]:
-        """Return flagged miners and detailed violations for a given scope.
+        """Return flagged copiers and detailed violations for a given scope.
 
-        The ratio criterion is shared / min(total_a, total_b) >= threshold.
+        The ratio criterion is ``shared / min(total_a, total_b) >= threshold``.
+
+        Directional attribution:
+            When a pair exceeds the threshold, the later uploader (by S3
+            LastModified in ``uploads``) is identified as the copier and is
+            the *only* hotkey added to the cheater set. The earlier
+            uploader (the victim) is deliberately left intact. When
+            direction cannot be resolved (see :func:`_attribute_pair_direction`
+            for the abstain criteria), the violation is logged but NEITHER
+            side is gated. We prefer a missed detection over punishing a
+            victim.
 
         Returns:
             Tuple of:
-            - flagged: Miners appearing in at least one violating pair
-            - details: One record per violating pair capturing magnitude and scope
+            - flagged: Copiers appearing in at least one directionally
+              resolved violating pair. Victims are never included.
+            - details: One record per violating pair. When direction is
+              resolved, the record carries ``copier`` and ``victim``; when
+              unresolved, both are ``None``.
         """
         flagged: set[str] = set()
         details: list[CopycatViolation] = []
@@ -228,26 +382,54 @@ class CopycatTracker:
             if shared <= 0:
                 continue
             miner_a, miner_b = tuple(pair_key)
-            total_a = totals.get(miner_a, 0)
-            total_b = totals.get(miner_b, 0)
-            denominator = min(total_a, total_b)
+            denominator = min(totals.get(miner_a, 0), totals.get(miner_b, 0))
             if denominator <= 0:
                 continue
             ratio = shared / float(denominator)
-            if ratio >= threshold:
-                flagged.update((miner_a, miner_b))
-                details.append(
-                    CopycatViolation(
-                        miner_a=miner_a,
-                        miner_b=miner_b,
-                        shared=shared,
-                        denominator=denominator,
-                        ratio=ratio,
-                        threshold=threshold,
-                        scope=scope,
-                        window_start=window_start,
-                    )
+            if ratio < threshold:
+                continue
+
+            attribution = _attribute_pair_direction(miner_a, miner_b, uploads)
+            if not attribution.is_resolved:
+                # Log the violation but do not gate either side. This is
+                # the explicit fix for the pre-Tier-0 victim-punishment
+                # bug: we used to ``flagged.update((miner_a, miner_b))``
+                # here, which zeroed the victim's metrics alongside the
+                # attacker's. On the subnet 81 investigation this was
+                # actively penalising UID 53 and UID 7 (Oriea) while the
+                # real copycats (UIDs 20/229) stayed below the window
+                # threshold.
+                logger.warning(
+                    "Copycat threshold exceeded but upload-time direction "
+                    "unresolved; suppressing gating. miner_a=%s miner_b=%s "
+                    "shared=%d denom=%d ratio=%.3f threshold=%.2f scope=%s "
+                    "window=%d",
+                    miner_a,
+                    miner_b,
+                    shared,
+                    denominator,
+                    ratio,
+                    threshold,
+                    scope,
+                    window_start,
                 )
+            elif attribution.copier is not None:
+                flagged.add(attribution.copier)
+
+            details.append(
+                CopycatViolation(
+                    miner_a=miner_a,
+                    miner_b=miner_b,
+                    shared=shared,
+                    denominator=denominator,
+                    ratio=ratio,
+                    threshold=threshold,
+                    scope=scope,
+                    window_start=window_start,
+                    copier=attribution.copier,
+                    victim=attribution.victim,
+                )
+            )
         return flagged, details
 
 
@@ -287,25 +469,31 @@ class CopycatService:
     async def detect_cheaters(
         self,
         window: int,
-        miner_rollout_counters: dict[str, tuple[Counter[str], int]],
+        submissions: dict[str, MinerCopycatSubmission],
         uid_by_hotkey: dict[str, int],
         monitor: Any | None = None,
     ) -> tuple[set[str], set[str], list[CopycatViolation]]:
         """Detect copycat cheaters for a window.
 
         Args:
-            window: Window start block number
-            miner_rollout_counters: Map of hotkey -> (digest_counter, total_rollouts)
-            uid_by_hotkey: Mapping of hotkey to UID (for monitor namespacing)
-            monitor: Optional monitoring client
+            window: Window start block number.
+            submissions: Per-hotkey :class:`MinerCopycatSubmission` records
+                assembled by :meth:`WindowProcessor.process_window`. Each
+                record bundles the miner's digest counter, rollout total,
+                and S3 ``LastModified`` upload timestamp; there is no
+                parallel ``uploads_by_hotkey`` parameter because everything
+                the detector needs for one miner lives in one object.
+            uid_by_hotkey: Mapping of hotkey to UID (for monitor namespacing).
+            monitor: Optional monitoring client.
 
         Returns:
             Tuple of:
-            - window_cheaters: Miners exceeding window threshold
-            - interval_cheaters: Miners exceeding interval threshold
-            - all_violations: All violation details for logging
+            - window_cheaters: Copiers exceeding the window threshold
+              (victims excluded by directional attribution).
+            - interval_cheaters: Copiers exceeding the interval threshold.
+            - all_violations: All violation details for logging.
         """
-        if not miner_rollout_counters:
+        if not submissions:
             return set(), set(), []
 
         # Time the copycat detection if monitor available
@@ -321,7 +509,7 @@ class CopycatService:
                 interval_violation_details,
                 window_all_pairs,
                 interval_all_pairs,
-            ) = COPYCAT_TRACKER.ingest_window(window, miner_rollout_counters)
+            ) = COPYCAT_TRACKER.ingest_window(window, submissions)
 
         # Log detection metrics to monitor
         if monitor:
@@ -335,21 +523,40 @@ class CopycatService:
             except Exception:
                 pass
 
-        # Log all violations
+        # Log all violations. When direction is resolved (copier/victim set),
+        # surface them explicitly so operators can tell at a glance who was
+        # gated and who was the victim. When direction is unresolved, log as
+        # an unresolved pair — only the copier (if any) is gated by
+        # ``_find_cheaters``, so this is purely informational.
         all_violations = window_violation_details + interval_violation_details
         for violation in all_violations:
-            logger.warning(
-                "Copycat overlap detected: miners %s & %s shared=%d denom=%d ratio=%.3f "
-                "threshold=%.2f scope=%s window=%d",
-                violation.miner_a,
-                violation.miner_b,
-                violation.shared,
-                violation.denominator,
-                violation.ratio,
-                violation.threshold,
-                violation.scope,
-                violation.window_start,
-            )
+            if violation.copier is not None and violation.victim is not None:
+                logger.warning(
+                    "Copycat gated: copier=%s victim=%s shared=%d denom=%d "
+                    "ratio=%.3f threshold=%.2f scope=%s window=%d",
+                    violation.copier,
+                    violation.victim,
+                    violation.shared,
+                    violation.denominator,
+                    violation.ratio,
+                    violation.threshold,
+                    violation.scope,
+                    violation.window_start,
+                )
+            else:
+                logger.warning(
+                    "Copycat overlap (direction unresolved, no gating): "
+                    "miners %s & %s shared=%d denom=%d ratio=%.3f "
+                    "threshold=%.2f scope=%s window=%d",
+                    violation.miner_a,
+                    violation.miner_b,
+                    violation.shared,
+                    violation.denominator,
+                    violation.ratio,
+                    violation.threshold,
+                    violation.scope,
+                    violation.window_start,
+                )
 
         # Log per-miner proximity metrics to monitor
         if monitor:

--- a/grail/validation/sampling.py
+++ b/grail/validation/sampling.py
@@ -67,7 +67,7 @@ class MinerSampler:
         uid_by_hotkey: dict[str, int] | None = None,
         heartbeat_callback: Any = None,
         deadline_ts: float | None = None,
-    ) -> list[str]:
+    ) -> tuple[list[str], dict[str, float | None]]:
         """Find miners with window files for the given window.
 
         Active miners are those that uploaded:
@@ -85,13 +85,20 @@ class MinerSampler:
             deadline_ts: If set, require LastModified <= this deadline (unix seconds)
 
         Returns:
-            List of hotkeys with available window files
+            Tuple of:
+            - ``active_hotkeys``: Miners whose window file exists, is large
+              enough, and arrived before the deadline.
+            - ``upload_times``: ``{hotkey: unix_timestamp}`` for each active
+              miner, pulled from the S3 ``LastModified`` header of the
+              parquet object. Consumed by the copycat detector's directional
+              attribution to distinguish a copier (later uploader) from a
+              victim (earlier uploader). Values are never miner-supplied.
         """
         semaphore = asyncio.Semaphore(self._concurrency)
         late_counter: dict[str, int] = {"count": 0}
         too_small_counter: dict[str, int] = {"count": 0}
 
-        async def _check(hotkey: str) -> tuple[str, bool]:
+        async def _check(hotkey: str) -> tuple[str, bool, float | None]:
             filename = f"grail/windows/{hotkey}-window-{window}.parquet"
             bucket = chain_manager.get_bucket_for_hotkey(hotkey)
             uid = uid_by_hotkey.get(hotkey) if uid_by_hotkey else None
@@ -99,7 +106,7 @@ class MinerSampler:
 
             # Skip miners without a committed bucket (no fallback)
             if bucket is None:
-                return hotkey, False
+                return hotkey, False, None
 
             async with semaphore:
                 # Update heartbeat to prevent watchdog timeout during long
@@ -135,7 +142,7 @@ class MinerSampler:
                             miner_id,
                             window,
                         )
-                        return hotkey, False
+                        return hotkey, False, None
 
                     # Check if file was late
                     if was_late:
@@ -147,9 +154,9 @@ class MinerSampler:
                             upload_time or -1,
                             deadline_ts,
                         )
-                        return hotkey, False
+                        return hotkey, False, None
 
-                    return hotkey, bool(exists)
+                    return hotkey, bool(exists), upload_time
                 except TimeoutError:
                     elapsed = time.time() - start_time
                     logger.debug(
@@ -158,13 +165,14 @@ class MinerSampler:
                         window,
                         elapsed,
                     )
-                    return hotkey, False
+                    return hotkey, False, None
                 except Exception as e:
                     logger.error(f"Error checking window file for hotkey {hotkey}: {e}")
-                    return hotkey, False
+                    return hotkey, False, None
 
         results = await asyncio.gather(*(_check(hk) for hk in meta_hotkeys))
-        active = [hk for hk, ok in results if ok]
+        active = [hk for hk, ok, _ in results if ok]
+        upload_times: dict[str, float | None] = {hk: ts for hk, ok, ts in results if ok}
 
         logger.info(
             "Discovered %d/%d active miners for window %d", len(active), len(meta_hotkeys), window
@@ -182,7 +190,7 @@ class MinerSampler:
                 window,
             )
 
-        return active
+        return active, upload_times
 
     def select_miners_for_validation(
         self,

--- a/grail/validation/service.py
+++ b/grail/validation/service.py
@@ -590,7 +590,7 @@ class ValidationService:
         with timer_ctx:
             if self._miner_sampler is None:
                 raise RuntimeError("MinerSampler not initialized")
-            active_hotkeys = await self._miner_sampler.discover_active_miners(
+            active_hotkeys, active_upload_times = await self._miner_sampler.discover_active_miners(
                 meta_hotkeys=list(meta.hotkeys),
                 window=target_window,
                 chain_manager=self._chain_manager,
@@ -616,20 +616,30 @@ class ValidationService:
 
         # Determine subset to validate
         if test_mode:
-            # Test mode: validate only TRAINER_UID
-            if TRAINER_UID < len(meta.hotkeys):
-                trainer_hotkey = meta.hotkeys[TRAINER_UID]
-                hotkeys_to_check = [trainer_hotkey]
+            # Test mode: validate only the validator's OWN wallet (i.e. the
+            # miner this validator is co-located with). Useful for verifying
+            # a freshly-built miner's rollouts in isolation: the validator
+            # still loads checkpoints from TRAINER_UID's bucket but it
+            # ignores all other miners on the network and only fetches the
+            # parquet files we just uploaded ourselves.
+            own_hotkey = self._wallet.hotkey.ss58_address
+            if own_hotkey in meta.hotkeys:
+                own_uid = meta.hotkeys.index(own_hotkey)
+                hotkeys_to_check = [own_hotkey]
                 logger.info(
-                    "Test mode: Validating TRAINER_UID %d with hotkey %s",
+                    "Test mode: validating own wallet UID %d (hotkey %s); "
+                    "trainer checkpoints still loaded from UID %d",
+                    own_uid,
+                    own_hotkey[:12],
                     TRAINER_UID,
-                    trainer_hotkey[:12],
                 )
             else:
                 logger.warning(
-                    "Test mode: TRAINER_UID %d not found in metagraph (size: %d)",
-                    TRAINER_UID,
+                    "Test mode: own hotkey %s not found in metagraph (size: %d); "
+                    "validator wallet is not registered on subnet %d",
+                    own_hotkey[:12],
                     len(meta.hotkeys),
+                    self._netuid if hasattr(self, "_netuid") else -1,
                 )
                 hotkeys_to_check = []
         elif MINER_SAMPLING_ENABLED:
@@ -689,6 +699,7 @@ class ValidationService:
                 env_config=env_config,
                 heartbeat_callback=heartbeat_callback,
                 deadline_ts=deadline_ts,
+                uploads_by_hotkey=active_upload_times,
             )
 
         # Update inference counts for weight computation

--- a/grail/validation/window_processor.py
+++ b/grail/validation/window_processor.py
@@ -18,7 +18,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..infrastructure.chain import GrailChainManager
 from ..logging_utils import miner_log_context
-from .copycat_service import CopycatService
+from .copycat_service import CopycatService, MinerCopycatSubmission
 from .miner_validator import (
     FAILURE_FLAG_KEY,
     MinerValidator,
@@ -87,6 +87,7 @@ class WindowProcessor:
         env_config: WindowEnvConfig,
         heartbeat_callback: Any = None,
         deadline_ts: float | None = None,
+        uploads_by_hotkey: dict[str, float | None] | None = None,
     ) -> WindowResults:
         """Process a complete validation window.
 
@@ -110,6 +111,12 @@ class WindowProcessor:
                 the service aborts the window and never reaches this method.
             heartbeat_callback: Optional watchdog heartbeat callback
             deadline_ts: Upload deadline timestamp (unix seconds)
+            uploads_by_hotkey: Per-hotkey S3 LastModified timestamps from
+                ``MinerSampler.discover_active_miners``. Used by
+                ``CopycatService.detect_cheaters`` for directional
+                attribution: the later uploader of a violating pair is the
+                copier; the earlier uploader is the victim and is not gated.
+                When omitted, the copycat detector abstains from gating.
 
         Returns:
             WindowResults with all aggregated metrics and rollouts
@@ -123,7 +130,14 @@ class WindowProcessor:
 
         # Initialize aggregation structures
         window_metrics: dict[str, dict[str, int]] = {}
-        miner_rollout_counters: dict[str, tuple[Counter[str], int]] = {}
+        # Raw per-miner copycat inputs collected during the validation loop.
+        # Upload-time (from S3 LastModified, forwarded from the sampler) is
+        # joined in at the end to produce MinerCopycatSubmission objects
+        # handed to the copycat detector. Keeping this as an intermediate
+        # dict (rather than constructing submissions piecemeal) keeps the
+        # per-miner error path at line ~248 focused on metrics and avoids
+        # exposing upload-time to the validator loop.
+        miner_digest_counters: dict[str, tuple[Counter[str], int]] = {}
         text_logs_emitted: dict[str, int] = {}
 
         # Aggregated counters
@@ -199,7 +213,7 @@ class WindowProcessor:
                 # No longer aggregate rollouts for upload
 
                 if result.digest_counter is not None:
-                    miner_rollout_counters[miner_hotkey] = (
+                    miner_digest_counters[miner_hotkey] = (
                         result.digest_counter,
                         result.total_inferences_in_file,
                     )
@@ -263,6 +277,22 @@ class WindowProcessor:
             metrics.get("estimated_valid", 0) for metrics in window_metrics.values()
         )
 
+        # Build per-miner submission objects for copycat detection. This is
+        # the single place where the per-miner digest counters meet the
+        # per-miner upload timestamps propagated from the sampler: building
+        # MinerCopycatSubmission here is what lets ``detect_cheaters``
+        # receive everything it needs in one argument, rather than
+        # threading ``uploads_by_hotkey`` through every downstream method.
+        upload_times = uploads_by_hotkey or {}
+        submissions: dict[str, MinerCopycatSubmission] = {
+            hotkey: MinerCopycatSubmission(
+                digest_counter=counter,
+                total_rollouts=total,
+                upload_time=upload_times.get(hotkey),
+            )
+            for hotkey, (counter, total) in miner_digest_counters.items()
+        }
+
         # Copycat detection and gating
         (
             window_cheaters,
@@ -270,7 +300,7 @@ class WindowProcessor:
             violations,
         ) = await self._copycat_service.detect_cheaters(
             window=window,
-            miner_rollout_counters=miner_rollout_counters,
+            submissions=submissions,
             uid_by_hotkey=uid_by_hotkey,
             monitor=monitor,
         )

--- a/tests/unit/validation/test_copycat_detection.py
+++ b/tests/unit/validation/test_copycat_detection.py
@@ -513,3 +513,83 @@ class TestDirectionalGating:
 
         assert i_cheat == {"copier"}, "victim must not accumulate as a cheater"
         assert all(v.copier == "copier" and v.victim == "victim" for v in i_det)
+
+    def test_interval_attribution_survives_victim_going_offline(
+        self,
+        tracker: CopycatTracker,
+    ) -> None:
+        """Regression: interval-scope attribution must still work when the
+        victim is absent from the current window.
+
+        Reproduces the blocker found independently by two reviewers against
+        an earlier draft of this change. Before the fix,
+        ``CopycatTracker._find_cheaters`` at interval scope used only the
+        current window's ``uploads`` map. When the victim went offline
+        mid-interval, ``_attribute_pair_direction`` returned
+        :meth:`_PairAttribution.unresolved` because ``uploads[victim]`` was
+        missing, and the accumulated cheat escaped gating entirely.
+
+        The fix archives per-miner upload times on the tracker as
+        ``interval_upload_times``, updated on each ingested window and
+        cleared on ``reset_interval``. This test locks in the expected
+        post-fix behaviour: a victim who stops submitting must still be
+        recognised as the earlier uploader, and the copier must still be
+        flagged at interval scope.
+        """
+        tracker.reset_interval(0)
+
+        # Windows 1-5: both submit, accumulate interval overlap.
+        # Per-window ratio 4/100 = 0.04 (just under window threshold 0.05)
+        # but interval after 5 windows is 20/500 = 0.04 > interval threshold 0.03.
+        both = {
+            "victim": _sub(Counter({"shared": 4, "u_a": 96}), 100, upload_time=100.0),
+            "copier": _sub(Counter({"shared": 4, "u_b": 96}), 100, upload_time=200.0),
+        }
+        for i in range(5):
+            tracker.ingest_window(100 * i, both)
+
+        # Window 6: victim goes offline, only copier submits. The
+        # submissions map has no entry for the victim, so the current-window
+        # uploads view also has no entry for them. The pre-fix code would
+        # abstain here; the fix must remember the victim's upload time
+        # from windows 1-5.
+        copier_only = {
+            "copier": _sub(Counter({"u_b_new": 100}), 100, upload_time=600.0),
+        }
+        _, _, i_cheat, i_det, _, _ = tracker.ingest_window(600, copier_only)
+
+        assert i_cheat == {"copier"}, (
+            "interval-scope attribution must still fire on the absent victim's "
+            "accumulated overlap — this is the regression guard for the "
+            "reviewers' blocker finding"
+        )
+        assert "victim" not in i_cheat, "victim is offline but must not be gated"
+        victim_copier_pairs = [v for v in i_det if {"victim", "copier"} == {v.miner_a, v.miner_b}]
+        assert victim_copier_pairs, "violation record should still exist"
+        assert victim_copier_pairs[0].copier == "copier"
+        assert victim_copier_pairs[0].victim == "victim"
+
+    def test_reset_interval_clears_archived_upload_times(
+        self,
+        tracker: CopycatTracker,
+    ) -> None:
+        """`reset_interval` must clear interval_upload_times along with
+        interval_pair_overlap and interval_totals. Otherwise a stale
+        upload_time from a previous interval could leak into attribution.
+        """
+        tracker.reset_interval(0)
+        submissions = {
+            "miner_a": _sub(Counter({"x": 10}), 10, upload_time=100.0),
+            "miner_b": _sub(Counter({"y": 10}), 10, upload_time=200.0),
+        }
+        tracker.ingest_window(0, submissions)
+        assert tracker.interval_upload_times == {
+            "miner_a": 100.0,
+            "miner_b": 200.0,
+        }
+
+        tracker.reset_interval(1)
+        assert tracker.interval_upload_times == {}, (
+            "reset_interval must clear archived upload times to avoid "
+            "cross-interval timestamp leakage"
+        )

--- a/tests/unit/validation/test_copycat_detection.py
+++ b/tests/unit/validation/test_copycat_detection.py
@@ -15,8 +15,27 @@ from grail.validation.copycat_service import (
     COPYCAT_INTERVAL_THRESHOLD,
     COPYCAT_WINDOW_THRESHOLD,
     CopycatTracker,
+    MinerCopycatSubmission,
 )
 from tests.conftest import TEST_MODEL_ID
+
+
+def _sub(
+    digest_counter: Counter[str],
+    total: int,
+    upload_time: float | None = None,
+) -> MinerCopycatSubmission:
+    """Build a :class:`MinerCopycatSubmission` for test ergonomics.
+
+    Centralising construction here keeps the tests focused on their
+    assertions and means that if we add new fields to the submission
+    dataclass in a later tier, we only update this one helper.
+    """
+    return MinerCopycatSubmission(
+        digest_counter=digest_counter,
+        total_rollouts=total,
+        upload_time=upload_time,
+    )
 
 
 def generate_sat_completion_tokens(
@@ -86,43 +105,51 @@ class TestCopycatTracker:
     def test_no_overlap_no_violations(self, tracker: CopycatTracker) -> None:
         """No violations when miners have unique completions."""
         tracker.reset_interval(0)
-        miner_rollouts = {
-            "miner_a": (Counter({"digest_1": 5}), 5),
-            "miner_b": (Counter({"digest_2": 5}), 5),
-            "miner_c": (Counter({"digest_3": 5}), 5),
+        submissions = {
+            "miner_a": _sub(Counter({"digest_1": 5}), 5, upload_time=100.0),
+            "miner_b": _sub(Counter({"digest_2": 5}), 5, upload_time=110.0),
+            "miner_c": _sub(Counter({"digest_3": 5}), 5, upload_time=120.0),
         }
-        w_cheat, w_det, i_cheat, i_det, _, _ = tracker.ingest_window(100, miner_rollouts)
+        w_cheat, w_det, i_cheat, i_det, _, _ = tracker.ingest_window(100, submissions)
         assert len(w_cheat) == 0
         assert len(w_det) == 0
         assert len(i_cheat) == 0
         assert len(i_det) == 0
 
     def test_window_threshold_violation(self, tracker: CopycatTracker) -> None:
-        """Flags miners exceeding window threshold."""
+        """Flags the later uploader (copier) when a pair exceeds threshold.
+
+        With directional gating, only the later uploader is added to the
+        cheater set. The earlier uploader is the victim and is not gated.
+        """
         tracker.reset_interval(0)
         # miner_a: 100 rollouts, 6 shared with miner_b
         # miner_b: 100 rollouts, 6 shared with miner_a
         # Ratio: 6 / min(100, 100) = 0.06 > COPYCAT_WINDOW_THRESHOLD (0.05)
-        miner_rollouts = {
-            "miner_a": (Counter({"shared": 6, "unique_a": 94}), 100),
-            "miner_b": (Counter({"shared": 6, "unique_b": 94}), 100),
+        # miner_a uploaded first (t=100.0), miner_b uploaded later (t=200.0)
+        # so miner_b is the copier, miner_a is the victim.
+        submissions = {
+            "miner_a": _sub(Counter({"shared": 6, "unique_a": 94}), 100, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared": 6, "unique_b": 94}), 100, upload_time=200.0),
         }
-        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, miner_rollouts)
-        assert "miner_a" in w_cheat
-        assert "miner_b" in w_cheat
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, submissions)
+        assert w_cheat == {"miner_b"}, "only the later uploader should be flagged"
+        assert "miner_a" not in w_cheat, "victim must not be gated (Tier 0 bugfix)"
         assert len(w_det) == 1
         assert w_det[0].shared == 6
         assert w_det[0].ratio == 0.06
+        assert w_det[0].copier == "miner_b"
+        assert w_det[0].victim == "miner_a"
 
     def test_window_below_threshold_no_violation(self, tracker: CopycatTracker) -> None:
         """No violation when overlap below window threshold."""
         tracker.reset_interval(0)
         # Ratio: 4 / min(100, 100) = 0.04 < 0.05
-        miner_rollouts = {
-            "miner_a": (Counter({"shared": 4, "unique_a": 96}), 100),
-            "miner_b": (Counter({"shared": 4, "unique_b": 96}), 100),
+        submissions = {
+            "miner_a": _sub(Counter({"shared": 4, "unique_a": 96}), 100, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared": 4, "unique_b": 96}), 100, upload_time=200.0),
         }
-        w_cheat, w_det, _, _, w_all, _ = tracker.ingest_window(100, miner_rollouts)
+        w_cheat, w_det, _, _, w_all, _ = tracker.ingest_window(100, submissions)
         assert len(w_cheat) == 0
         assert len(w_det) == 0
         # But should appear in all_pairs
@@ -130,30 +157,35 @@ class TestCopycatTracker:
         assert w_all[0].ratio == 0.04
 
     def test_interval_accumulation(self, tracker: CopycatTracker) -> None:
-        """Interval-level detection accumulates across windows."""
+        """Interval-level detection accumulates across windows.
+
+        Uses distinct upload times so directional attribution can resolve
+        the copier across every contributing window.
+        """
         tracker.reset_interval(0)
         # Each window: 4 shared out of 100 = 0.04 per window (below window threshold)
         # but accumulated over 10 windows: 40 shared / 1000 total = 0.04 > 0.03
-        rollouts = {
-            "miner_a": (Counter({"shared": 4, "unique_a": 96}), 100),
-            "miner_b": (Counter({"shared": 4, "unique_b": 96}), 100),
+        submissions = {
+            "miner_a": _sub(Counter({"shared": 4, "unique_a": 96}), 100, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared": 4, "unique_b": 96}), 100, upload_time=200.0),
         }
         # Ingest multiple windows to accumulate interval overlap
         for i in range(10):
-            _, _, i_cheat, i_det, _, _ = tracker.ingest_window(100 * i, rollouts)
+            _, _, i_cheat, i_det, _, _ = tracker.ingest_window(100 * i, submissions)
         # After 10 windows: 40 shared / 1000 total = 0.04 > 0.03
-        assert "miner_a" in i_cheat
-        assert "miner_b" in i_cheat
+        assert i_cheat == {"miner_b"}
         assert i_det[0].ratio >= COPYCAT_INTERVAL_THRESHOLD
+        assert i_det[0].copier == "miner_b"
+        assert i_det[0].victim == "miner_a"
 
     def test_interval_reset_clears_state(self, tracker: CopycatTracker) -> None:
         """Interval reset clears accumulated statistics."""
         tracker.reset_interval(0)
-        miner_rollouts = {
-            "miner_a": (Counter({"shared": 8}), 10),
-            "miner_b": (Counter({"shared": 8}), 10),
+        submissions = {
+            "miner_a": _sub(Counter({"shared": 8}), 10, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared": 8}), 10, upload_time=200.0),
         }
-        tracker.ingest_window(100, miner_rollouts)
+        tracker.ingest_window(100, submissions)
         assert tracker.interval_totals["miner_a"] == 10
 
         # Reset to new interval
@@ -162,37 +194,43 @@ class TestCopycatTracker:
         assert len(tracker.interval_pair_overlap) == 0
 
     def test_three_way_overlap(self, tracker: CopycatTracker) -> None:
-        """Multiple miners sharing digests creates pairwise violations."""
+        """Multiple miners sharing digests produce pairwise violations.
+
+        The earliest uploader is the victim; every later uploader is a
+        copier and is added to the cheater set.
+        """
         tracker.reset_interval(0)
         # All three share 8 out of 100 = 0.08 > 0.05 (severe copying)
-        miner_rollouts = {
-            "miner_a": (Counter({"shared_all": 8, "unique_a": 92}), 100),
-            "miner_b": (Counter({"shared_all": 8, "unique_b": 92}), 100),
-            "miner_c": (Counter({"shared_all": 8, "unique_c": 92}), 100),
+        submissions = {
+            "miner_a": _sub(Counter({"shared_all": 8, "unique_a": 92}), 100, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared_all": 8, "unique_b": 92}), 100, upload_time=200.0),
+            "miner_c": _sub(Counter({"shared_all": 8, "unique_c": 92}), 100, upload_time=300.0),
         }
-        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, miner_rollouts)
-        # All three should be flagged (appears in 3 pairs)
-        assert "miner_a" in w_cheat
-        assert "miner_b" in w_cheat
-        assert "miner_c" in w_cheat
-        # Should have 3 pairs: (a,b), (a,c), (b,c)
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, submissions)
+        # miner_a is the earliest and therefore the victim on every pair;
+        # miner_b is later than miner_a (copier) and earlier than miner_c
+        # (victim), miner_c is the latest (copier on every pair it touches).
+        assert w_cheat == {"miner_b", "miner_c"}
+        assert "miner_a" not in w_cheat, "earliest uploader must not be gated"
+        # Should have 3 pair records: (a,b), (a,c), (b,c)
         assert len(w_det) == 3
 
     def test_asymmetric_counts(self, tracker: CopycatTracker) -> None:
-        """Uses min(total_a, total_b) as denominator."""
+        """Uses min(total_a, total_b) as denominator; gates the later uploader."""
         tracker.reset_interval(0)
         # miner_a: 200 rollouts, 8 shared
         # miner_b: 100 rollouts, 8 shared
         # Ratio: 8 / min(200, 100) = 8 / 100 = 0.08 > 0.05
-        miner_rollouts = {
-            "miner_a": (Counter({"shared": 8, "unique_a": 192}), 200),
-            "miner_b": (Counter({"shared": 8, "unique_b": 92}), 100),
+        submissions = {
+            "miner_a": _sub(Counter({"shared": 8, "unique_a": 192}), 200, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared": 8, "unique_b": 92}), 100, upload_time=200.0),
         }
-        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, miner_rollouts)
-        assert "miner_a" in w_cheat
-        assert "miner_b" in w_cheat
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, submissions)
+        assert w_cheat == {"miner_b"}
         assert w_det[0].denominator == 100
         assert w_det[0].ratio == 0.08
+        assert w_det[0].copier == "miner_b"
+        assert w_det[0].victim == "miner_a"
         # Verify threshold constants are in range
         assert 0.0 < COPYCAT_WINDOW_THRESHOLD < 1.0
         assert 0.0 < COPYCAT_INTERVAL_THRESHOLD < 1.0
@@ -221,20 +259,25 @@ class TestCopycatWithRealisticSAT:
     ) -> None:
         """Miners with unique SAT solutions produce no violations."""
         tracker.reset_interval(0)
-        miner_rollouts = {}
+        submissions: dict[str, MinerCopycatSubmission] = {}
         for i, miner_id in enumerate(["alice", "bob", "charlie"]):
             seeds = [i * 100 + j for j in range(5)]
             digests = make_rollout_data(sat_prompt_tokens, seeds, [True] * 5)
-            miner_rollouts[miner_id] = (Counter(digests), len(digests))
+            submissions[miner_id] = _sub(Counter(digests), len(digests), upload_time=100.0 + i)
 
-        w_cheat, _, i_cheat, _, _, _ = tracker.ingest_window(100, miner_rollouts)
+        w_cheat, _, i_cheat, _, _, _ = tracker.ingest_window(100, submissions)
         assert len(w_cheat) == 0
         assert len(i_cheat) == 0
 
     def test_copied_sat_completions_detected(
         self, tracker: CopycatTracker, sat_prompt_tokens: list[int]
     ) -> None:
-        """Detects when miners copy SAT completions from each other."""
+        """Detects when miners copy SAT completions from each other.
+
+        With directional gating, only the later uploader (``bob``) is
+        flagged. Alice, who uploaded first, is the victim and keeps her
+        metrics.
+        """
         tracker.reset_interval(0)
         # alice & bob: 8 copied + 92 unique out of 100 (8% overlap > 5% threshold)
         # charlie: all unique
@@ -246,18 +289,22 @@ class TestCopycatWithRealisticSAT:
         bob_data = make_rollout_data(sat_prompt_tokens, bob_seeds, bob_flags)
         charlie_data = make_rollout_data(sat_prompt_tokens, list(range(3000, 3100)), [True] * 100)
 
-        miner_rollouts = {
-            "alice": (Counter(alice_data), len(alice_data)),
-            "bob": (Counter(bob_data), len(bob_data)),
-            "charlie": (Counter(charlie_data), len(charlie_data)),
+        submissions = {
+            "alice": _sub(Counter(alice_data), len(alice_data), upload_time=100.0),
+            "bob": _sub(Counter(bob_data), len(bob_data), upload_time=200.0),
+            "charlie": _sub(Counter(charlie_data), len(charlie_data), upload_time=300.0),
         }
 
-        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, miner_rollouts)
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(100, submissions)
 
-        # alice and bob flagged (8/100 = 0.08 > 0.05), charlie not
-        assert "alice" in w_cheat and "bob" in w_cheat
+        # Only the later uploader (bob) is flagged; alice is the victim.
+        assert w_cheat == {"bob"}
+        assert "alice" not in w_cheat
         assert "charlie" not in w_cheat
-        assert any({"alice", "bob"} == {v.miner_a, v.miner_b} for v in w_det)
+        alice_bob_pairs = [v for v in w_det if {"alice", "bob"} == {v.miner_a, v.miner_b}]
+        assert alice_bob_pairs, "alice↔bob violation should be recorded"
+        assert alice_bob_pairs[0].copier == "bob"
+        assert alice_bob_pairs[0].victim == "alice"
 
     def test_multiple_sat_prompts_mixed_overlap(
         self, tracker: CopycatTracker, sat_prompts: list[str]
@@ -270,7 +317,7 @@ class TestCopycatWithRealisticSAT:
 
         # miner1 & miner2: 3 copied + 97 unique (3% overlap, below 5% threshold)
         # miner3: all unique
-        miner_rollouts = {}
+        submissions: dict[str, MinerCopycatSubmission] = {}
         for i, miner_id in enumerate(["miner1", "miner2", "miner3"]):
             prompt_tokens = tokenizer.encode(sat_prompts[i % len(sat_prompts)])
             if i < 2:
@@ -281,11 +328,188 @@ class TestCopycatWithRealisticSAT:
                 seeds = list(range(3000, 3100))
                 flags = [True] * 100
             digests = make_rollout_data(prompt_tokens, seeds, flags)
-            miner_rollouts[miner_id] = (Counter(digests), len(digests))
+            submissions[miner_id] = _sub(Counter(digests), len(digests), upload_time=100.0 + i)
 
-        _, _, _, _, w_all, _ = tracker.ingest_window(200, miner_rollouts)
+        _, _, _, _, w_all, _ = tracker.ingest_window(200, submissions)
 
         # 3% overlap < 5% threshold (not flagged)
         pair = [v for v in w_all if {"miner1", "miner2"} == {v.miner_a, v.miner_b}]
         if pair:
             assert pair[0].ratio < COPYCAT_WINDOW_THRESHOLD
+
+
+class TestDirectionalGating:
+    """Regression tests for the Tier 0 victim-punishment fix.
+
+    Background:
+        The pre-Tier-0 detector flagged **both** sides of a violating pair
+        with ``flagged.update((miner_a, miner_b))``. On subnet 81 this
+        actively penalised honest singleton miners (UIDs 53 and 7) who
+        were being scraped by coldkey ``5CAL2bA5...``: the scrapers'
+        interval-scope overlap crossed the 3% threshold against UIDs 53
+        and 7, and the gating logic zeroed the victims' metrics too.
+
+    These tests pin the new semantics:
+
+    - Only the later uploader (copier) is added to the cheater set.
+    - When direction cannot be resolved (missing or equal timestamps), the
+      detector ABSTAINS: no one is gated, even though a violation is logged.
+    """
+
+    @pytest.fixture
+    def tracker(self) -> CopycatTracker:
+        return CopycatTracker()
+
+    @pytest.fixture
+    def overlapping_digests(self) -> tuple[Counter[str], Counter[str]]:
+        """Two digest counters that exceed the window threshold.
+
+        Returns a pair where ``shared / min(total_a, total_b) = 0.06``,
+        i.e. just above ``COPYCAT_WINDOW_THRESHOLD`` (0.05).
+        """
+        return (
+            Counter({"shared": 6, "unique_a": 94}),
+            Counter({"shared": 6, "unique_b": 94}),
+        )
+
+    def test_only_later_uploader_is_gated(
+        self,
+        tracker: CopycatTracker,
+        overlapping_digests: tuple[Counter[str], Counter[str]],
+    ) -> None:
+        """Later uploader is the copier; earlier uploader is the untouched victim."""
+        tracker.reset_interval(0)
+        counter_a, counter_b = overlapping_digests
+        submissions = {
+            "victim": _sub(counter_a, 100, upload_time=1_000.0),
+            "copier": _sub(counter_b, 100, upload_time=1_050.0),
+        }
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(1, submissions)
+
+        assert w_cheat == {"copier"}, "only the copier should be gated"
+        assert "victim" not in w_cheat, "victim must never be gated"
+
+        assert len(w_det) == 1
+        violation = w_det[0]
+        assert violation.copier == "copier"
+        assert violation.victim == "victim"
+        assert violation.ratio >= COPYCAT_WINDOW_THRESHOLD
+
+    def test_role_swap_when_upload_order_inverts(
+        self,
+        tracker: CopycatTracker,
+        overlapping_digests: tuple[Counter[str], Counter[str]],
+    ) -> None:
+        """Swapping upload order swaps copier/victim — proves it's not alphabetical."""
+        tracker.reset_interval(0)
+        counter_a, counter_b = overlapping_digests
+        submissions = {
+            "alpha": _sub(counter_a, 100, upload_time=2_000.0),  # later
+            "bravo": _sub(counter_b, 100, upload_time=1_000.0),  # earlier
+        }
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(1, submissions)
+
+        assert w_cheat == {"alpha"}
+        assert w_det[0].copier == "alpha"
+        assert w_det[0].victim == "bravo"
+
+    def test_missing_upload_time_abstains(
+        self,
+        tracker: CopycatTracker,
+        overlapping_digests: tuple[Counter[str], Counter[str]],
+    ) -> None:
+        """If either upload_time is None, no one is gated.
+
+        This is the safe default: the detector prefers a missed detection
+        to punishing the wrong side. The violation should still appear in
+        the details list so monitoring can see it.
+        """
+        tracker.reset_interval(0)
+        counter_a, counter_b = overlapping_digests
+        submissions = {
+            "miner_a": _sub(counter_a, 100, upload_time=None),
+            "miner_b": _sub(counter_b, 100, upload_time=1_000.0),
+        }
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(1, submissions)
+
+        assert w_cheat == set(), "unresolved direction must gate nobody"
+        assert len(w_det) == 1, "violation still recorded for observability"
+        assert w_det[0].copier is None
+        assert w_det[0].victim is None
+
+    def test_equal_upload_time_abstains(
+        self,
+        tracker: CopycatTracker,
+        overlapping_digests: tuple[Counter[str], Counter[str]],
+    ) -> None:
+        """Equal timestamps (within resolution) are treated as unresolved."""
+        tracker.reset_interval(0)
+        counter_a, counter_b = overlapping_digests
+        submissions = {
+            "miner_a": _sub(counter_a, 100, upload_time=4_242.0),
+            "miner_b": _sub(counter_b, 100, upload_time=4_242.0),
+        }
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(1, submissions)
+
+        assert w_cheat == set(), "equal timestamps must abstain"
+        assert len(w_det) == 1
+        assert w_det[0].copier is None
+        assert w_det[0].victim is None
+
+    def test_below_threshold_is_not_gated_even_with_direction(
+        self,
+        tracker: CopycatTracker,
+    ) -> None:
+        """Directional gating only applies to pairs that exceed the threshold."""
+        tracker.reset_interval(0)
+        # 4 / 100 = 0.04 < 0.05 window threshold
+        submissions = {
+            "miner_a": _sub(Counter({"shared": 4, "u_a": 96}), 100, upload_time=100.0),
+            "miner_b": _sub(Counter({"shared": 4, "u_b": 96}), 100, upload_time=200.0),
+        }
+        w_cheat, w_det, _, _, _, _ = tracker.ingest_window(1, submissions)
+
+        assert w_cheat == set()
+        assert w_det == []
+
+    def test_three_way_earliest_is_spared(self, tracker: CopycatTracker) -> None:
+        """In an N-way cluster, the earliest uploader is never gated.
+
+        Reproduces the layout that caused the bug: three miners all share
+        the same completion set at a rate above threshold. Under the old
+        symmetric flagger, all three were zeroed. Under directional
+        gating, only the two later uploaders are gated.
+        """
+        tracker.reset_interval(0)
+        submissions = {
+            "earliest": _sub(Counter({"shared_all": 8, "unique_a": 92}), 100, upload_time=1.0),
+            "mid": _sub(Counter({"shared_all": 8, "unique_b": 92}), 100, upload_time=2.0),
+            "latest": _sub(Counter({"shared_all": 8, "unique_c": 92}), 100, upload_time=3.0),
+        }
+        w_cheat, _, _, _, _, _ = tracker.ingest_window(1, submissions)
+
+        assert "earliest" not in w_cheat, (
+            "the earliest uploader must not be gated — regression guard for "
+            "the Tier 0 victim-punishment fix"
+        )
+        assert w_cheat == {"mid", "latest"}
+
+    def test_copier_gating_persists_across_interval(
+        self,
+        tracker: CopycatTracker,
+    ) -> None:
+        """At interval scope, the copier is flagged using the most recent window's
+        upload times, and the victim remains untouched across the whole interval.
+        """
+        tracker.reset_interval(0)
+        # 4 shared per window → below window threshold but above 3% interval
+        # threshold after 10 windows.
+        submissions = {
+            "victim": _sub(Counter({"shared": 4, "u_a": 96}), 100, upload_time=100.0),
+            "copier": _sub(Counter({"shared": 4, "u_b": 96}), 100, upload_time=200.0),
+        }
+        for i in range(10):
+            _, _, i_cheat, i_det, _, _ = tracker.ingest_window(100 * i, submissions)
+
+        assert i_cheat == {"copier"}, "victim must not accumulate as a cheater"
+        assert all(v.copier == "copier" and v.victim == "victim" for v in i_det)


### PR DESCRIPTION
## Summary
- Stops the copycat detector from zeroing honest victims alongside attackers
- Uses S3 `LastModified` to identify the later uploader as the copier; abstains when unresolved
- Archives per-miner upload times across the interval so cross-window attribution keeps working when a victim goes offline

## Test plan
- [x] 32 unit tests pass including 9 new directional-gating regression tests
- [x] ruff + pyright clean on modified files
- [ ] Deployed to `basilica-grail-validator` with live log verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Copycat violations now include directional attribution identifying which miner copied from which.

* **Improvements**
  - Miner sampling now captures upload timestamp data for more accurate validation.
  - Copycat detection enhanced with better handling for unresolved attribution cases.
  - Updated test mode miner selection logic.

* **Tests**
  - Added comprehensive test coverage for directional attribution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->