### PR TITLE
fix: raise ValueError on empty base_state in apply_sparse_delta

### DIFF
--- a/grail/infrastructure/delta_checkpoint.py
+++ b/grail/infrastructure/delta_checkpoint.py
@@ -134,6 +134,8 @@ def apply_sparse_delta(
 
     # Infer dtype from base_state if not specified
     if target_dtype is None:
+        if not base_state:
+            raise ValueError("Cannot infer target_dtype: base_state is empty")
         target_dtype = next(iter(base_state.values())).dtype
 
     for name, base_tensor in base_state.items():

--- a/tests/unit/infrastructure/test_delta_checkpoint.py
+++ b/tests/unit/infrastructure/test_delta_checkpoint.py
@@ -202,6 +202,16 @@ class TestApplySparseDelta:
 
         assert result["weight"].dtype == torch.bfloat16
 
+    def test_empty_base_state_raises_value_error(self) -> None:
+        """Test that empty base_state with target_dtype=None raises ValueError instead of StopIteration."""
+        with pytest.raises(ValueError, match="Cannot infer target_dtype: base_state is empty"):
+            apply_sparse_delta({}, {}, {}, target_dtype=None)
+
+    def test_empty_base_state_with_explicit_dtype(self) -> None:
+        """Test that empty base_state with explicit target_dtype returns empty dict."""
+        result = apply_sparse_delta({}, {}, {}, target_dtype=torch.float32)
+        assert result == {}
+
 
 class TestRoundTrip:
     """Test round-trip: compute delta, apply delta, verify identical."""


### PR DESCRIPTION
## Summary

- Fixes #66 — `apply_sparse_delta` crashes with unhandled `StopIteration` when `base_state` is empty and `target_dtype=None`
- Adds an explicit guard that raises `ValueError("Cannot infer target_dtype: base_state is empty")` before the `next(iter(...))` call
- Adds two regression tests covering: (1) empty base_state raises `ValueError`, (2) empty base_state with explicit dtype returns empty dict

## Root Cause

In `grail/infrastructure/delta_checkpoint.py` line 137, dtype is inferred by calling `next(iter(base_state.values()))`. When `base_state` is an empty dict, this raises `StopIteration` which propagates uncaught to callers in `checkpoint_consumer.py` (lines 439-444 and 1315-1319) that pass `target_dtype=None`.

## Fix

```python
if target_dtype is None:
    if not base_state:
        raise ValueError("Cannot infer target_dtype: base_state is empty")
    target_dtype = next(iter(base_state.values())).dtype
```

## Test plan

- [x] All 24 existing `test_delta_checkpoint.py` tests pass
- [x] New test `test_empty_base_state_raises_value_error` confirms `ValueError` is raised
- [x] New test `test_empty_base_state_with_explicit_dtype` confirms empty base_state + explicit dtype returns `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling for sparse delta operations when base state is empty and no target data type is specified. Users now receive a clear, descriptive error message instead of an obscure inference failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->